### PR TITLE
Fix autorender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,10 @@ from KaTeX for auto-rendered content are:
         {left: "\\[", right: "\\]", display: true}
     ]
     '''
+
+The version of KaTeX used is controlled by the ``katex_version`` config setting,
+and the specific delimiters written to the HTML when math mode is encountered
+are controlled by the ``katex_inline`` and ``katex_display`` config settings.
+By default, ``katex_inline`` is ``[r'\(', r'\)']`` and ``katex_display`` is
+``[r'\[', r'\]']``. If you change these, make sure to update the ``delimiters``
+by adding the ``katex_options`` config setting.

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ sphinxcontrib-katex
 A Sphinx extension for rendering math on HTML pages.
 
 The extension uses `KaTeX <https://khan.github.io/KaTeX/>`_ for
-rendering of math in HTML pages. Itis designed as a replacement
-for mathjax which is slower in rednering, but comes as a build
-in extension with sphinx
+rendering of math in HTML pages. It is designed as a replacement
+for MathJax which is slower in rendering, but comes as a built
+in extension with Sphinx,
 `sphinx.ext.mathjax
 <https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -45,3 +45,19 @@ If you would like to add some LaTeX macros (``\def``) you can use the
         "\\dirac": "\\operatorname{\\delta}\\left(#1\\right)",
         "\\scalarprod": "\\left\\langle#1,#2\\right\\rangle",
         '''
+
+You can also add other
+`KaTeX options <https://github.com/Khan/KaTeX#rendering-options>`_ or
+`auto-rendering options <https://github.com/Khan/KaTeX/tree/master/contrib/auto-render#api>`_
+with the ``katex_options`` config setting, for example, the default delimiters
+from KaTeX for auto-rendered content are:
+
+.. code-block:: python
+
+    katex_options = r'''
+    delimiters : [
+        {left: "$$", right: "$$", display: true},
+        {left: "\\(", right: "\\)", display: false},
+        {left: "\\[", right: "\\]", display: true}
+    ]
+    '''

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@ import io
 from setuptools import setup, find_packages
 
 __version__ = 'unknown'
-for line in open('sphinxcontrib/katex.py'):
-    if line.startswith('__version__'):
-        exec(line)
-        break
+with open('sphinxcontrib/katex.py') as katex_py:
+    for line in katex_py:
+        if line.startswith('__version__'):
+            exec(line)
+            break
 
 
 def readfile(filename):

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -133,13 +133,17 @@ def copy_katex_css_file(app, css_file_name):
 
 
 def katex_autorenderer_content(app):
-    content = 'renderMathInElement(document.body, latex_options);'
+    content = '''
+document.addEventListener("DOMContentLoaded", function() {
+  renderMathInElement(document.body, latex_options);
+});
+'''
+    prefix = 'latex_options = {'
+    suffix = '}'
     macros = app.config.katex_macros
     if len(macros) > 0:
-        prefix = 'latex_options = { macros: {'
-        suffix = '}}'
-        content = '\n'.join([prefix, macros, suffix, content])
-    return content
+        macros = 'macros: {' + macros + '},'
+    return '\n'.join([prefix, macros, suffix, content])
 
 
 def setup_static_path(app):

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -143,7 +143,8 @@ document.addEventListener("DOMContentLoaded", function() {
     macros = app.config.katex_macros
     if len(macros) > 0:
         macros = 'macros: {' + macros + '},'
-    return '\n'.join([prefix, macros, suffix, content])
+    options = app.config.katex_options
+    return '\n'.join([prefix, macros, options, suffix, content])
 
 
 def setup_static_path(app):
@@ -176,6 +177,7 @@ def setup(app):
     app.add_config_value('katex_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('katex_display', [r'\[', r'\]'], 'html')
     app.add_config_value('katex_macros', '', 'html')
+    app.add_config_value('katex_options', '', 'html')
     app.connect('builder-inited', builder_inited)
     app.connect('build-finished', builder_finished)
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -162,18 +162,18 @@ def setup(app):
         raise ExtensionError('katex: other math package is already loaded')
 
     # Include KaTex CSS and JS files
-    katex_url = 'https://cdn.jsdelivr.net/npm/katex@'
     app.add_config_value('katex_version',
                          '0.9.0', False)
-    katex_url += app.config.katex_version + '/'
+    katex_url = 'https://cdn.jsdelivr.net/npm/katex@{katex_version}/dist/'.format(
+        katex_version=app.config.katex_version)
     app.add_config_value('katex_css_path',
-                         katex_url + 'dist/katex.min.css',
+                         katex_url + 'katex.min.css',
                          False)
     app.add_config_value('katex_js_path',
-                         katex_url + 'dist/katex.min.js',
+                         katex_url + 'katex.min.js',
                          False)
     app.add_config_value('katex_autorender_path',
-                         katex_url + 'dist/contrib/auto-render.min.js',
+                         katex_url + 'contrib/auto-render.min.js',
                          False)
     app.add_config_value('katex_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('katex_display', [r'\[', r'\]'], 'html')

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -135,10 +135,10 @@ def copy_katex_css_file(app, css_file_name):
 def katex_autorenderer_content(app):
     content = '''
 document.addEventListener("DOMContentLoaded", function() {
-  renderMathInElement(document.body, latex_options);
+  renderMathInElement(document.body, katex_options);
 });
 '''
-    prefix = 'latex_options = {'
+    prefix = 'katex_options = {'
     suffix = '}'
     macros = app.config.katex_macros
     if len(macros) > 0:

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -24,7 +24,6 @@ from sphinx.ext.mathbase import get_node_equation_number
 
 
 __version__ = '0.1.6'
-katex_version = '0.9.0'
 filename_css = 'katex-math.css'
 filename_autorenderer = 'katex_autorenderer.js'
 
@@ -163,16 +162,18 @@ def setup(app):
         raise ExtensionError('katex: other math package is already loaded')
 
     # Include KaTex CSS and JS files
-    katex_url = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/'
-    katex_url += katex_version
+    katex_url = 'https://cdn.jsdelivr.net/npm/katex@'
+    app.add_config_value('katex_version',
+                         '0.9.0', False)
+    katex_url += app.config.katex_version + '/'
     app.add_config_value('katex_css_path',
-                         katex_url + '/katex.min.css',
+                         katex_url + 'dist/katex.min.css',
                          False)
     app.add_config_value('katex_js_path',
-                         katex_url + '/katex.min.js',
+                         katex_url + 'dist/katex.min.js',
                          False)
     app.add_config_value('katex_autorender_path',
-                         katex_url + '/contrib/auto-render.min.js',
+                         katex_url + 'dist/contrib/auto-render.min.js',
                          False)
     app.add_config_value('katex_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('katex_display', [r'\[', r'\]'], 'html')


### PR DESCRIPTION
Hi! I was having some trouble with the auto-render functionality, and it seemed like it was because the js was loaded before the body rather than after. The KaTeX auto-render readme suggests wrapping in a function that loads when the DOM is finished loading: https://github.com/Khan/KaTeX/tree/master/contrib/auto-render#usage

I also added a new configuration option for more general KaTeX configuration, and made the version a configurable variable. Please let me know any further changes or if you want me to drop any of these changes.