### PR TITLE
Enhance handling of KaTeX options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 sphinxcontrib-katex
 ===================
 
-A `Sphinx extension`_ for rendering math on HTML pages.
+A `Sphinx extension`_ for rendering math in HTML pages.
 
 The extension uses `KaTeX`_ for rendering of math in HTML pages. It is designed
-as a replacement for `MathJax`_ which is slower in rendering, but comes as a
-built-in extension with `Sphinx`_, named `sphinx.ext.mathjax`_.
+as a replacement for the built-in extension `sphinx.ext.mathjax`_, which uses
+`MathJax`_ for rendering.
 
 * Download: https://pypi.python.org/pypi/sphinxcontrib-katex/#downloads
 
@@ -14,7 +14,6 @@ built-in extension with `Sphinx`_, named `sphinx.ext.mathjax`_.
 .. _Sphinx extension: http://www.sphinx-doc.org/en/master/extensions.html
 .. _MathJax: https://www.mathjax.org
 .. _KaTeX: https://khan.github.io/KaTeX/
-.. _Sphinx: http://www.sphinx-doc.org
 .. _sphinx.ext.mathjax:
     https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py
 

--- a/README.rst
+++ b/README.rst
@@ -37,18 +37,18 @@ In ``conf.py`` of your sphinx project, add the extension with:
 Configuration
 -------------
 
-The behavior of the KaTeX extension can be changed by configuration entries that
-you can add to your ``conf.py`` file of your sphinx project. In the following
-all configuration entries are listed and their default values are shown.
+The behavior of the sphinxcontrib.katex can be changed by configuration entries
+in the ``conf.py`` file of your documentation project. In the following all
+configuration entries are listed and their default values are shown.
 
 .. code-block:: python
 
     katex_version = 0.9
-    katex_css_path = 'https://cdn.jsdelivr.net/npm/katex@' +
-                     katex_version +
+    katex_css_path = 'https://cdn.jsdelivr.net/npm/katex@' + \
+                     katex_version + \
                      '/dist/katex.min.css'
-    katex_js_path = 'https://cdn.jsdelivr.net/npm/katex@' +
-                     katex_version +
+    katex_js_path = 'https://cdn.jsdelivr.net/npm/katex@' + \
+                     katex_version + \
                      '/dist/contrib/auto-render.min.js'
     katex_inline = [r'\(', r'\)']
     katex_display = [r'\[', r'\]']
@@ -60,11 +60,7 @@ CSS and JS files. The specific delimiters written to HTML when math mode is
 encountered are controlled by ``katex_inline`` and ``katex_display``.
 
 The ``katex_options`` setting allows you to change all available official 
-`KaTeX rendering options`_. For example, 
-If you would like to add some LaTeX macros (``\def``) you can use the
-``katex_macros`` config setting, for example:
-
-.. code-block:: python
+`KaTeX rendering options`_.
 
 You can also add `KaTeX auto-rendering options`_ to the ``katex_options``, but
 be aware that the ``delimiters`` entry gets always overwritten by the entries of

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,22 @@
 sphinxcontrib-katex
 ===================
 
-A Sphinx extension for rendering math on HTML pages.
+A `Sphinx extension`_ for rendering math on HTML pages.
 
-The extension uses `KaTeX <https://khan.github.io/KaTeX/>`_ for
-rendering of math in HTML pages. It is designed as a replacement
-for MathJax which is slower in rendering, but comes as a built
-in extension with Sphinx,
-`sphinx.ext.mathjax
-<https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py>`_.
+The extension uses `KaTeX`_ for rendering of math in HTML pages. It is designed
+as a replacement for `MathJax`_ which is slower in rendering, but comes as a
+built-in extension with `Sphinx`_, named `sphinx.ext.mathjax`_.
 
 * Download: https://pypi.python.org/pypi/sphinxcontrib-katex/#downloads
 
 * Development: https://github.com/hagenw/sphinxcontrib-katex/
+
+.. _Sphinx extension: http://www.sphinx-doc.org/en/master/extensions.html
+.. _MathJax: https://www.mathjax.org
+.. _KaTeX: https://khan.github.io/KaTeX/
+.. _Sphinx: http://www.sphinx-doc.org
+.. _sphinx.ext.mathjax:
+    https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py
 
 
 Usage
@@ -22,7 +26,7 @@ Installation::
 
     pip install sphinxcontrib-katex
 
-In your sphinx project, add the extension with:
+In ``conf.py`` of your sphinx project, add the extension with:
 
 .. code-block:: python
 
@@ -30,41 +34,105 @@ In your sphinx project, add the extension with:
         'sphinxcontrib.katex',
         ]
 
+
+Configuration
+-------------
+
+The behavior of the KaTeX extension can be changed by configuration entries that
+you can add to your ``conf.py`` file of your sphinx project. In the following
+all configuration entries are listed and their default values are shown.
+
+.. code-block:: python
+
+    katex_version = 0.9
+    katex_css_path = 'https://cdn.jsdelivr.net/npm/katex@' +
+                     katex_version +
+                     '/dist/katex.min.css'
+    katex_js_path = 'https://cdn.jsdelivr.net/npm/katex@' +
+                     katex_version +
+                     '/dist/contrib/auto-render.min.js'
+    katex_inline = [r'\(', r'\)']
+    katex_display = [r'\[', r'\]']
+    katex_options = {}
+
+The version of KaTeX used is controlled by the ``katex_version`` config setting,
+which per default is also automatically added to the URL strings for the KaTeX
+CSS and JS files. The specific delimiters written to HTML when math mode is
+encountered are controlled by ``katex_inline`` and ``katex_display``.
+
+The ``katex_options`` setting allows you to change all available official 
+`KaTeX rendering options`_. For example, 
 If you would like to add some LaTeX macros (``\def``) you can use the
 ``katex_macros`` config setting, for example:
 
 .. code-block:: python
 
-    katex_macros = r'''
-        "\\i": "\\mathrm{i}",
-        "\\e": "\\mathrm{e}^{#1}",
-        "\\w": "\\omega",
-        "\\vec": "\\mathbf{#1}",
-        "\\x": "\\vec{x}",
-        "\\d": "\\operatorname{d}\\!{}",
-        "\\dirac": "\\operatorname{\\delta}\\left(#1\\right)",
-        "\\scalarprod": "\\left\\langle#1,#2\\right\\rangle",
-        '''
+You can also add `KaTeX auto-rendering options`_ to the ``katex_options``, but
+be aware that the ``delimiters`` entry gets always overwritten by the entries of
+``katex_inline`` and ``katex_display``.
 
-You can also add other
-`KaTeX options <https://github.com/Khan/KaTeX#rendering-options>`_ or
-`auto-rendering options <https://github.com/Khan/KaTeX/tree/master/contrib/auto-render#api>`_
-with the ``katex_options`` config setting, for example, the default delimiters
-from KaTeX for auto-rendered content are:
+.. _KaTeX rendering options:
+    https://github.com/Khan/KaTeX#rendering-options
+.. _KaTeX auto-rendering options: 
+    https://github.com/Khan/KaTeX/tree/master/contrib/auto-render#api
+
+
+LaTeX Macros
+------------
+
+Most probably you want to add some ogf your LaTeX math commands for the
+rendering. In KaTeX this is supported by LaTeX macros (``\def``).
+You can use the ``katex_options`` configuration setting to add those:
 
 .. code-block:: python
 
-    katex_options = r'''
-    delimiters : [
-        {left: "$$", right: "$$", display: true},
-        {left: "\\(", right: "\\)", display: false},
-        {left: "\\[", right: "\\]", display: true}
-    ]
-    '''
+    katex_options = {
+        r'''macros:  {
+            "\\i": "\\mathrm{i}",
+            "\\e": "\\mathrm{e}^{#1}",
+            "\\vec": "\\mathbf{#1}",
+            "\\x": "\\vec{x}",
+            "\\d": "\\operatorname{d}\\!{}",
+            "\\dirac": "\\operatorname{\\delta}\\left(#1\\right)",
+            "\\scalarprod": "\\left\\langle#1,#2\\right\\rangle",
+        }
+        '''
+        }
 
-The version of KaTeX used is controlled by the ``katex_version`` config setting,
-and the specific delimiters written to the HTML when math mode is encountered
-are controlled by the ``katex_inline`` and ``katex_display`` config settings.
-By default, ``katex_inline`` is ``[r'\(', r'\)']`` and ``katex_display`` is
-``[r'\[', r'\]']``. If you change these, make sure to update the ``delimiters``
-by adding the ``katex_options`` config setting.
+The disadvantage of this option is that those macros will be only available in
+the HTML based `Sphinx builders`_. If you want to use them in the LaTeX based
+builders as well you can add them in an extra file in your projet, for example
+``definitions.py``:
+
+.. code-block:: python
+
+    latex_macros = r"""
+        \def \i                {\mathrm{i}}
+        \def \e              #1{\mathrm{e}^{#1}}
+        \def \vec            #1{\mathbf{#1}}
+        \def \x                {\vec{x}}
+        \def \d                {\operatorname{d}\!}
+        \def \dirac          #1{\operatorname{\delta}\left(#1\right)}
+        \def \scalarprod   #1#2{\left\langle#1,#2\right\rangle}
+    """
+
+Note, that we used proper LaTeX syntax here and not the special one required for
+``katex_options``. This is fine as ``sphinxcontrib.katex`` provides a function
+to translate to the required KaTeX syntax. To use our definitions for HTML and
+LaTeX `Sphinx builders`_ add the following to your ``conf.py``.
+
+.. code-block:: python
+
+    import sys
+
+    import sphinxcontrib.katex as katex
+
+    # Allow import/extensions from current path
+    sys.path.insert(0, os.path.abspath('.'))
+    from definitions import latex_macros
+
+    # Translate LaTeX macros to the required KaTeX format and add to options
+    katex_macros = katex.latex_defs_to_katex_macros(latex_macros)
+    katex_options = 'macros: {' + katex_macros + '}'
+
+.. _Sphinx builders: http://www.sphinx-doc.org/en/master/builders.html

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -98,7 +98,7 @@ def html_visit_displaymath(self, node):
 def builder_inited(app):
     if not (app.config.katex_js_path and app.config.katex_css_path and
             app.config.katex_autorender_path):
-        raise ExtensionError('katex pathes not set')
+        raise ExtensionError('KaTeX pathes not set')
     app.add_stylesheet(app.config.katex_css_path)
     app.add_javascript(app.config.katex_js_path)
     # Automatic math rendering

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -171,8 +171,8 @@ def setup(app):
     # Include KaTex CSS and JS files
     app.add_config_value('katex_version',
                          '0.9.0', False)
-    katex_url = 'https://cdn.jsdelivr.net/npm/katex@{katex_version}/dist/'.format(
-        katex_version=app.config.katex_version)
+    katex_url = 'https://cdn.jsdelivr.net/npm/katex@{version}/dist/'.format(
+        version=app.config.katex_version)
     app.add_config_value('katex_css_path',
                          katex_url + 'katex.min.css',
                          False)

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -41,8 +41,8 @@ def latex_defs_to_katex_macros(defs):
     -------
     import sphinxcontrib.katex as katex
     # Get your LaTeX defs into `latex_defs` and then do
-    katex_macros = katex.import_macros_from_latex(latex_defs)
-
+    latex_macros = katex.import_macros_from_latex(latex_defs)
+    katex_options = 'macros: {' + latex_macros + '}'
     '''
     # Remove empty lines
     defs = defs.strip()
@@ -139,11 +139,8 @@ document.addEventListener("DOMContentLoaded", function() {
 '''
     prefix = 'katex_options = {'
     suffix = '}'
-    macros = app.config.katex_macros
-    if len(macros) > 0:
-        macros = 'macros: {' + macros + '},'
     options = app.config.katex_options
-    return '\n'.join([prefix, macros, options, suffix, content])
+    return '\n'.join([prefix, options, suffix, content])
 
 
 def setup_static_path(app):
@@ -177,7 +174,6 @@ def setup(app):
                          False)
     app.add_config_value('katex_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('katex_display', [r'\[', r'\]'], 'html')
-    app.add_config_value('katex_macros', '', 'html')
     app.add_config_value('katex_options', '', 'html')
     app.connect('builder-inited', builder_inited)
     app.connect('build-finished', builder_finished)

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -137,7 +137,17 @@ document.addEventListener("DOMContentLoaded", function() {
   renderMathInElement(document.body, katex_options);
 });
 '''
-    prefix = 'katex_options = {'
+    katex_delimiters = app.config.katex_inline + app.config.katex_display
+    # Check if we have to add extra "\" for delimiters
+    for idx, delimiter in enumerate(katex_delimiters):
+        if delimiter[0] == '\\':
+            katex_delimiters[idx] = '\\' + katex_delimiters[idx]
+    # Set chosen delimiters for the auto-rendering options of KaTeX
+    delimiters = r'''[
+        {{ left: "\{}", right: "\{}", display: false }},
+        {{ left: "\{}", right: "\{}", display: true }}
+        ],'''.format(*katex_delimiters)
+    prefix = 'katex_options = { delimiters: ' + delimiters
     suffix = '}'
     options = app.config.katex_options
     return '\n'.join([prefix, options, suffix, content])

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -143,14 +143,17 @@ document.addEventListener("DOMContentLoaded", function() {
         if delimiter[0] == '\\':
             katex_delimiters[idx] = '\\' + katex_delimiters[idx]
     # Set chosen delimiters for the auto-rendering options of KaTeX
-    delimiters = r'''[
-        {{ left: "\{}", right: "\{}", display: false }},
-        {{ left: "\{}", right: "\{}", display: true }}
+    delimiters = r'''delimiters: [
+        {{ left: "{}", right: "{}", display: false }},
+        {{ left: "{}", right: "{}", display: true }}
         ],'''.format(*katex_delimiters)
-    prefix = 'katex_options = { delimiters: ' + delimiters
+    prefix = 'katex_options = {'
     suffix = '}'
     options = app.config.katex_options
-    return '\n'.join([prefix, options, suffix, content])
+    # Ensure list of options ends with ',' to append delimiters
+    if not options[-1:] == ',':
+        options += ','
+    return '\n'.join([prefix, options, delimiters, suffix, content])
 
 
 def setup_static_path(app):

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -169,7 +169,7 @@ def setup(app):
         mathbase_setup(app, (html_visit_math, None),
                        (html_visit_displaymath, None))
     except ExtensionError:
-        raise ExtensionError('katex: other math package is already loaded')
+        raise ExtensionError('KaTeX: other math package is already loaded')
 
     # Include KaTex CSS and JS files
     app.add_config_value('katex_version',


### PR DESCRIPTION
Changes are:

* document all available options
* remove the `katex_macros` option as it is already part of `katex_options`
* automatically set the delimiters for the KaTeX auto-renderer