### PR TITLE
Fix options bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ In ``conf.py`` of your sphinx project, add the extension with:
 Configuration
 -------------
 
-The behavior of the sphinxcontrib.katex can be changed by configuration entries
+The behavior of the ``sphinxcontrib.katex`` can be changed by configuration entries
 in the ``conf.py`` file of your documentation project. In the following all
 configuration entries are listed and their default values are shown.
 
@@ -59,7 +59,7 @@ which per default is also automatically added to the URL strings for the KaTeX
 CSS and JS files. The specific delimiters written to HTML when math mode is
 encountered are controlled by ``katex_inline`` and ``katex_display``.
 
-The ``katex_options`` setting allows you to change all available official 
+The ``katex_options`` setting allows you to change all available official
 `KaTeX rendering options`_.
 
 You can also add `KaTeX auto-rendering options`_ to the ``katex_options``, but
@@ -68,21 +68,21 @@ be aware that the ``delimiters`` entry gets always overwritten by the entries of
 
 .. _KaTeX rendering options:
     https://github.com/Khan/KaTeX#rendering-options
-.. _KaTeX auto-rendering options: 
+.. _KaTeX auto-rendering options:
     https://github.com/Khan/KaTeX/tree/master/contrib/auto-render#api
 
 
 LaTeX Macros
 ------------
 
-Most probably you want to add some ogf your LaTeX math commands for the
+Most probably you want to add some of your LaTeX math commands for the
 rendering. In KaTeX this is supported by LaTeX macros (``\def``).
 You can use the ``katex_options`` configuration setting to add those:
 
 .. code-block:: python
 
     katex_options = {
-        r'''macros:  {
+        r'''macros: {
             "\\i": "\\mathrm{i}",
             "\\e": "\\mathrm{e}^{#1}",
             "\\vec": "\\mathbf{#1}",
@@ -96,7 +96,7 @@ You can use the ``katex_options`` configuration setting to add those:
 
 The disadvantage of this option is that those macros will be only available in
 the HTML based `Sphinx builders`_. If you want to use them in the LaTeX based
-builders as well you can add them in an extra file in your projet, for example
+builders as well you can add them in an extra file in your project, for example
 ``definitions.py``:
 
 .. code-block:: python

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -133,21 +133,22 @@ def copy_katex_css_file(app, css_file_name):
 
 
 def katex_autorenderer_content(app):
-    katex_delimiters = app.config.katex_inline + app.config.katex_display
-    # Check if we have to add extra "\" for delimiters
-    for idx, delimiter in enumerate(katex_delimiters):
-        if delimiter[0] == '\\':
-            katex_delimiters[idx] = '\\' + katex_delimiters[idx]
     content = dedent('''\
         document.addEventListener("DOMContentLoaded", function() {
           renderMathInElement(document.body, katex_options);
         });
         ''')
+    katex_inline = ['\\' + d if d[0] == '\\' else d for d in app.config.katex_inline]
+    katex_display = ['\\' + d if d[0] == '\\' else d for d in app.config.katex_display]
+    katex_delimiters = {
+        'katex_inline': katex_inline,
+        'katex_display': katex_display
+    }
     # Set chosen delimiters for the auto-rendering options of KaTeX
     delimiters = r'''delimiters: [
-        {{ left: "{}", right: "{}", display: false }},
-        {{ left: "{}", right: "{}", display: true }}
-        ],'''.format(*katex_delimiters)
+        {{ left: "{katex_inline[0]}", right: "{katex_inline[1]}", display: false }},
+        {{ left: "{katex_display[0]}", right: "{katex_display[1]}", display: true }}
+        ]'''.format(**katex_delimiters)
     prefix = 'katex_options = {'
     suffix = '}'
     options = app.config.katex_options

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -98,7 +98,7 @@ def html_visit_displaymath(self, node):
 def builder_inited(app):
     if not (app.config.katex_js_path and app.config.katex_css_path and
             app.config.katex_autorender_path):
-        raise ExtensionError('KaTeX pathes not set')
+        raise ExtensionError('KaTeX paths not set')
     app.add_stylesheet(app.config.katex_css_path)
     app.add_javascript(app.config.katex_js_path)
     # Automatic math rendering

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -151,7 +151,7 @@ document.addEventListener("DOMContentLoaded", function() {
     suffix = '}'
     options = app.config.katex_options
     # Ensure list of options ends with ',' to append delimiters
-    if not options[-1:] == ',':
+    if options and not options.endswith(','):
         options += ','
     return '\n'.join([prefix, options, delimiters, suffix, content])
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -15,6 +15,7 @@ import re
 import shutil
 from docutils import nodes
 from tempfile import mkdtemp
+from textwrap import dedent
 
 from sphinx.locale import _
 from sphinx.errors import ExtensionError
@@ -132,16 +133,16 @@ def copy_katex_css_file(app, css_file_name):
 
 
 def katex_autorenderer_content(app):
-    content = '''
-document.addEventListener("DOMContentLoaded", function() {
-  renderMathInElement(document.body, katex_options);
-});
-'''
     katex_delimiters = app.config.katex_inline + app.config.katex_display
     # Check if we have to add extra "\" for delimiters
     for idx, delimiter in enumerate(katex_delimiters):
         if delimiter[0] == '\\':
             katex_delimiters[idx] = '\\' + katex_delimiters[idx]
+    content = dedent('''\
+        document.addEventListener("DOMContentLoaded", function() {
+          renderMathInElement(document.body, katex_options);
+        });
+        ''')
     # Set chosen delimiters for the auto-rendering options of KaTeX
     delimiters = r'''delimiters: [
         {{ left: "{}", right: "{}", display: false }},


### PR DESCRIPTION
Hi,

Some of the changes added to 0.2.0 caused a bug if `katex_options` was blank.

I'm also curious why the delimiters are hard-coded and cannot be configured? There could be a case where a user wants to add some additional delimiters (for instance, if they have any raw text with math they want to format).