### PR TITLE
Handle change in math node structure in Sphinx 1.8.0

### DIFF
--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -68,10 +68,17 @@ def latex_defs_to_katex_macros(defs):
     return macros
 
 
+def get_latex(node):
+    if 'latex' in node.attributes:
+        return node['latex']  # for Sphinx < 1.8.0
+    else:
+        return node.astext()  # for Sphinx >= 1.8.0
+
+
 def html_visit_math(self, node):
     self.body.append(self.starttag(node, 'span', '', CLASS='math'))
     self.body.append(self.builder.config.katex_inline[0] +
-                     self.encode(node['latex']) +
+                     self.encode(get_latex(node)) +
                      self.builder.config.katex_inline[1] + '</span>')
     raise nodes.SkipNode
 
@@ -79,7 +86,7 @@ def html_visit_math(self, node):
 def html_visit_displaymath(self, node):
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     if node['nowrap']:
-        self.body.append(self.encode(node['latex']))
+        self.body.append(self.encode(get_latex(node)))
         self.body.append('</div>')
         raise nodes.SkipNode
 
@@ -90,7 +97,7 @@ def html_visit_displaymath(self, node):
         self.add_permalink_ref(node, _('Permalink to this equation'))
         self.body.append('</span>')
     self.body.append(self.builder.config.katex_display[0])
-    self.body.append(node['latex'])
+    self.body.append(get_latex(node))
     self.body.append(self.builder.config.katex_display[1])
     self.body.append('</div>\n')
     raise nodes.SkipNode


### PR DESCRIPTION
The structure of math-related nodes has changed in Sphinx 1.8.0, from being something like:
```xml
<displaymath latex="f(x) = x^2" />
```
to:
```xml
<math_block>f(x) = x^2</math_block>
```

While there appears to be some sort of workaround to enable the current usage present in Sphinx 1.8.0, (https://github.com/sphinx-doc/sphinx/blob/16533cff9a1e20fc10ec78eaf7c4796cd3552965/sphinx/addnodes.py#L203)
 it doesn't seem to actually work and the following traceback occurs:

```
Traceback (most recent call last):
  File ".../site-packages/sphinx/cmd/build.py", line 304, in build_main
    app.build(args.force_all, filenames)
  File ".../site-packages/sphinx/application.py", line 341, in build
    self.builder.build_update()
  File ".../site-packages/sphinx/builders/__init__.py", line 347, in build_update
    len(to_build))
  File ".../site-packages/sphinx/builders/__init__.py", line 412, in build
    self.write(docnames, list(updated_docnames), method)
  File ".../site-packages/sphinx/builders/__init__.py", line 593, in write
    self._write_serial(sorted(docnames))
  File ".../site-packages/sphinx/builders/__init__.py", line 604, in _write_serial
    self.write_doc(docname, doctree)
  File ".../site-packages/sphinx/builders/html.py", line 730, in write_doc
    self.docwriter.write(doctree, destination)
  File ".../site-packages/docutils/writers/__init__.py", line 80, in write
    self.translate()
  File ".../site-packages/sphinx/writers/html.py", line 58, in translate
    self.document.walkabout(visitor)
  File ".../site-packages/docutils/nodes.py", line 174, in walkabout
    if child.walkabout(visitor):
  File ".../site-packages/docutils/nodes.py", line 174, in walkabout
    if child.walkabout(visitor):
  File ".../site-packages/docutils/nodes.py", line 174, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 7 more times]
  File ".../site-packages/docutils/nodes.py", line 166, in walkabout
    visitor.dispatch_visit(self)
  File ".../site-packages/docutils/nodes.py", line 1882, in dispatch_visit
    return method(node)
  File ".../site-packages/sphinx/writers/html.py", line 873, in visit_math
    visit(self, node)
  File ".../site-packages/sphinxcontrib/katex.py", line 75, in html_visit_math
    self.builder.config.katex_inline[1] + '</span>')
  File ".../site-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'latex'
```

This PR works for both Sphinx 1.8 as well as older versions (tested on 1.7.9) by checking to see if the node has a `latex` before using it, and if not, calling the `astext()` method.