### PR TITLE
Remove deprecated sphinx.ext.mathbase.setup_math

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx>=1.6
+sphinx>=1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx>=1.8
+sphinx>=1.6

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -208,8 +208,11 @@ def setup(app):
             inline_renderers=(html_visit_math, None),
             block_renderers=(html_visit_displaymath, None)
         )
-    except ExtensionError:
-        raise ExtensionError('KaTeX: other math package is already loaded')
+    except AttributeError:
+        # Versions of sphinx<1.8 require setup_math instead
+        from sphinx.ext.mathbase import setup_math
+        setup_math(app, (html_visit_math, None),
+                   (html_visit_displaymath, None))
 
     # Include KaTex CSS and JS files
     katex_url = 'https://cdn.jsdelivr.net/npm/katex@{version}/dist/'.format(

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -20,7 +20,6 @@ from textwrap import dedent
 from sphinx.locale import _
 from sphinx.errors import ExtensionError
 from sphinx.util.osutil import copyfile
-from sphinx import add_html_math_renderer
 
 
 __version__ = '0.4.1'
@@ -204,8 +203,11 @@ def setup_static_path(app):
 
 def setup(app):
     try:
-        app.add_html_math_renderer((html_visit_math, None),
-                                   (html_visit_displaymath, None))
+        app.add_html_math_renderer(
+            'katex',
+            inline_renderers=(html_visit_math, None),
+            block_renderers=(html_visit_displaymath, None)
+        )
     except ExtensionError:
         raise ExtensionError('KaTeX: other math package is already loaded')
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -21,7 +21,6 @@ from sphinx.locale import _
 from sphinx.errors import ExtensionError
 from sphinx.util.osutil import copyfile
 from sphinx import add_html_math_renderer
-#from sphinx.ext.mathbase import setup_math as mathbase_setup
 
 
 __version__ = '0.4.1'

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -20,7 +20,8 @@ from textwrap import dedent
 from sphinx.locale import _
 from sphinx.errors import ExtensionError
 from sphinx.util.osutil import copyfile
-from sphinx.ext.mathbase import setup_math as mathbase_setup
+from sphinx import add_html_math_renderer
+#from sphinx.ext.mathbase import setup_math as mathbase_setup
 
 
 __version__ = '0.4.1'
@@ -204,8 +205,8 @@ def setup_static_path(app):
 
 def setup(app):
     try:
-        mathbase_setup(app, (html_visit_math, None),
-                       (html_visit_displaymath, None))
+        app.add_html_math_renderer((html_visit_math, None),
+                                   (html_visit_displaymath, None))
     except ExtensionError:
         raise ExtensionError('KaTeX: other math package is already loaded')
 


### PR DESCRIPTION
Sphinx deprecated the `sphinx.ext.mathbase.setup_math` function in 1.8 and replaced it by `	add_html_math_renderer`.

This means we have also to increase our sphinx dependency to be `>=1.8`.