### PR TITLE
DOC: add equation number example

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -157,3 +157,42 @@ environment for more complex matrices:
         \msum m z x       & \msum m z y       & \psum m (x^2 + y^2)
     \end{array}
     \right)
+
+
+Equation numbers
+----------------
+
+Some of Maxwell's equations are given in :eq:`gauss-law`,
+:eq:`gauss-law-magnetism`, and :eq:`maxwell-faraday-equation`.
+
+.. code-block:: rst
+
+    .. math::
+        :label: gauss-law
+
+        \nabla \cdot \mathbf{E} = 4 \pi \rho
+
+    .. math::
+        :label: gauss-law-magnetism
+
+        \nabla \cdot \mathbf{B} = 0
+
+    .. math::
+        :label: maxwell-faraday-equation
+
+        \nabla \times \mathbf{E} = -\frac{\partial \mathbf{B}}{\partial t}
+
+.. math::
+    :label: gauss-law
+
+    \nabla \cdot \mathbf{E} = 4 \pi \rho
+
+.. math::
+    :label: gauss-law-magnetism
+
+    \nabla \cdot \mathbf{B} = 0
+
+.. math::
+    :label: maxwell-faraday-equation
+
+    \nabla \times \mathbf{E} = -\frac{\partial \mathbf{B}}{\partial t}


### PR DESCRIPTION
This adds a few equations with equation numbers in the documentation.

It will provide a good test bed for checking the `:nowrap:` math option.