### PR TITLE
Add KaTeX example to index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,8 @@
     :end-line: 19
 
 .. toctree::
+    :hidden:
+
     usage
     configuration
     macros

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,3 +10,25 @@
     examples
     contributing
     version-history
+
+.. code-block:: rst
+
+    .. math::
+
+        \text{Rendered with \KaTeX} \\[18pt]
+
+        \gdef \f #1 {f(#1)}
+
+        \f{x} = \int_{-\infty}^\infty
+            \hat \f\xi\,e^{2 \pi i \xi x}
+            \,d\xi
+
+.. math::
+
+    \text{Rendered with \KaTeX} \\[18pt]
+
+    \gdef \f #1 {f(#1)}
+
+    \f{x} = \int_{-\infty}^\infty
+        \hat \f\xi\,e^{2 \pi i \xi x}
+        \,d\xi


### PR DESCRIPTION
Adds an example usage to the documentation start page and hides the TOC instead.