### PR TITLE
TST: add stripped down test for sphinx<=1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ python:
 matrix:
   include:
 
-  # a few older Sphinx releases using default Python version
-  - env: SPHINX="==1.6.2"
-  - env: SPHINX="==1.6.7"
-  - env: SPHINX="==1.7.5"
-  - env: SPHINX="==1.8.2"
+  # Default Python + latest Sphinx + check for broken links
+  - env: ADDITIONAL_COMMAND="python -m sphinx doc/ doc/_build/ -b linkcheck -W"
 
-  # a few Python versions using latest Sphinx release
+  # A few older Sphinx releases using default Python version and stripped down
+  # example from tests/
+  - env: SPHINX="==1.6.2" FOLDER="tests"
+  - env: SPHINX="==1.6.7" FOLDER="tests"
+  - env: SPHINX="==1.7.5" FOLDER="tests"
+  - env: SPHINX="==1.8.2" FOLDER="tests"
+
+  # A few Python versions using latest Sphinx release
   - python: "2.7"
   - python: "3.4"
   - python: "3.5"
@@ -28,9 +32,9 @@ install:
   - pip install sphinx$SPHINX
   - python setup.py install
 script:
-  - python -m sphinx doc/ doc/_build/ -b html -W
-  - python -m sphinx doc/ doc/_build/ -b latex -W
-  - python -m sphinx doc/ doc/_build/ -b linkcheck -W
+  - python -m sphinx ${FOLDER:-doc} ${FOLDER:-doc}/_build/ -c doc/ -b html -W
+  - python -m sphinx ${FOLDER:-doc} ${FOLDER:-doc}/_build/ -c doc/ -b latex -W
   # Test server side prerendering
   - katex -V
-  - python -m sphinx doc/ doc/_build/ -b html -D katex_prerender=1 -W
+  - python -m sphinx ${FOLDER:-doc} ${FOLDER:-doc}/_build/ -c doc/ -b html -D katex_prerender=1 -W
+  - $ADDITIONAL_COMMAND

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,6 +52,27 @@ It is also possible to automatically check if all links are still valid::
 .. _Sphinx: http://sphinx-doc.org/
 
 
+Running Tests
+^^^^^^^^^^^^^
+
+``sphinxcontrib.katex`` is supposed to work for all versions ``sphinx>=1.6``.
+To test that you have to use a stripped down version of the documentation that
+is provided in the ``tests/`` folder, as the documentation under ``doc/`` uses
+features that are only supported by ``sphinx>=1.8``.
+
+To test that everything works as expected, please execute:
+
+.. code-block:: bash
+
+   python -m sphinx tests/ tests/_build/ -c doc/ -b html -W
+   python -m sphinx tests/ tests/_build/ -c doc/ -b latex -W
+
+The same tests are automatically performed by Travis_ once you create a pull
+request on Github_.
+
+.. _Travis: https://travis-ci.org/hagenw/sphinxcontrib-katex/
+
+
 Creating a New Release
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,1 @@
-sphinx>=1.6
+sphinx>=1.8

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -1,0 +1,159 @@
+Math Rendering Examples
+=======================
+
+The examples start always with a code box showing the commands, which is
+followed by the resulting Sphinx output.
+
+Inline math
+-----------
+
+.. code-block:: rst
+
+    Some inline math :math:`x_1 + x_2 + ... + x_n, n \in \mathbb{Z}`,
+    followed by text.
+
+Some inline math :math:`x_1 + x_2 + ... + x_n, n \in \mathbb{Z}`,
+followed by text.
+
+
+Macros
+------
+
+You can define macros directly in your math directive.
+
+.. code-block:: rst
+
+    .. math::
+
+        \def \x {\mathbf{x}}
+        \def \w {\omega}
+        \def \d {\operatorname{d}\!}
+
+        P(\x,\w) = \oint_{\partial V} D(\x_0,\w) G(\x-\x_0,\w) \d A(\x_0)
+
+.. math::
+
+    \def \x {\mathbf{x}}
+    \def \w {\omega}
+    \def \d {\operatorname{d}\!}
+
+    P(\x,\w) = \oint_{\partial V} D(\x_0,\w) G(\x-\x_0,\w) \d A(\x_0)
+
+If you want to use them in the whole document, the best is to define them in
+:file:`conf.py` as part of the ``katex_options``.
+Afterwards, you can use them in every math directive.
+
+Aligned environment
+-------------------
+
+.. code-block:: rst
+
+    .. math::
+
+        \begin{aligned}
+            \dot{x} & = \sigma(y-x) \\
+            \dot{y} & = \rho x - y - xz \\
+            \dot{z} & = -\beta z + xy
+        \end{aligned}
+
+.. math::
+
+    \begin{aligned}
+        \dot{x} & = \sigma(y-x) \\
+        \dot{y} & = \rho x - y - xz \\
+        \dot{z} & = -\beta z + xy
+    \end{aligned}
+
+
+Array environment
+-----------------
+
+.. code-block:: rst
+
+    .. math::
+
+        \begin{array}{c:c:c:c:c:c}
+            \Gamma & \Delta & \Theta & \Lambda & \Xi & \Pi \\ \hdashline
+            \gamma & \delta & \theta & \lambda & \xi & \pi
+        \end{array}
+
+.. math::
+
+    \begin{array}{c:c:c:c:c:c}
+        \Gamma & \Delta & \Theta & \Lambda & \Xi & \Pi \\ \hdashline
+        \gamma & \delta & \theta & \lambda & \xi & \pi
+    \end{array}
+
+
+Case definitions
+----------------
+
+.. code-block:: rst
+
+    .. math::
+
+        f(n) = \begin{cases}
+            \frac{n}{2}, & \text{if } n\text{ is even} \\
+            3n+1,        & \text{if } n\text{ is odd}
+        \end{cases}
+
+.. math::
+
+     f(n) = \begin{cases}
+        \frac{n}{2}, & \text{if } n\text{ is even} \\
+        2n+1,        & \text{if } n\text{ is odd}
+    \end{cases}
+
+
+Matrices
+--------
+
+A simple matrix defined with the ``pmatrix`` environment:
+
+.. code-block:: rst
+
+    .. math::
+
+        \begin{pmatrix}
+            a_{11} & a_{12} & a_{13}\\
+            a_{21} & a_{22} & a_{23}\\
+            a_{31} & a_{32} & a_{33}
+        \end{pmatrix}
+
+.. math::
+
+    \begin{pmatrix}
+        a_{11} & a_{12} & a_{13}\\
+        a_{21} & a_{22} & a_{23}\\
+        a_{31} & a_{32} & a_{33}
+    \end{pmatrix}
+
+
+The ``pmatrix*`` environment is not available, but you can use the ``array``
+environment for more complex matrices:
+
+.. code-block:: rst
+
+    .. math::
+
+        \def \msum {-\textstyle\sum}
+        \def \psum {\phantom{-}\textstyle\sum}
+        I_{ik} = \left(
+        \begin{array}{lll}
+            \psum m (y^2+z^2) & \msum m x y       & \msum m x z         \\
+            \msum m y x       & \psum m (x^2+z^2) & \msum m y z         \\
+            \msum m z x       & \msum m z y       & \psum m (x^2 + y^2)
+        \end{array}
+        \right)
+
+.. math::
+
+    \def \msum {-\textstyle\sum}
+    \def \psum {\phantom{-}\textstyle\sum}
+    I_{ik} = \left(
+    \begin{array}{lll}
+        \psum m (y^2+z^2) & \msum m x y       & \msum m x z         \\
+        \msum m y x       & \psum m (x^2+z^2) & \msum m y z         \\
+        \msum m z x       & \msum m z y       & \psum m (x^2 + y^2)
+    \end{array}
+    \right)


### PR DESCRIPTION
As some functionality that we want to use in the actual documentation is only available in newer sphinx versions, we test only a sub set of the documentation for older versions of sphinx.
This way we don't have to drop support for those versions yet.