### PR TITLE
Fix inclusion of docs/ into PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include LICENSE
 include *.rst
 global-include requirements.txt
 recursive-include sphinxcontrib *.css
-recursive-include doc *.rst *.py
+recursive-include docs *.rst *.py


### PR DESCRIPTION
In `MANIFEST.in` it was still `doc/` included and not `docs/`.