### PR TITLE
Fix running katex command under windows

### DIFF
--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -11,6 +11,7 @@
 """
 
 import os
+import platform
 import re
 import shutil
 from docutils import nodes
@@ -76,8 +77,12 @@ def get_latex(node):
 
 
 def run_katex(latex, *options):
+    if platform.system() == 'Windows':
+        cmd = 'katex.cmd'
+    else:
+        cmd = 'katex'
     p = subprocess.Popen(
-        ('katex', ) + options,
+        (cmd, ) + options,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
         env=os.environ.copy()

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -79,7 +79,8 @@ def run_katex(latex, *options):
     p = subprocess.Popen(
         ('katex', ) + options,
         stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE
+        stdin=subprocess.PIPE,
+        env=os.environ.copy()
     )
     stdout, stderr = p.communicate(latex.encode('utf-8'))
     return stdout.decode('utf-8')


### PR DESCRIPTION
Fixes #29.

It adds the current environment to `Popen` and changes the katex command name to `katex.cmd` under Windows.