### PR TITLE
TST: run CI job under Windows and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
   - python: "nightly"
   - python: "pypy3"
 
+  # Test on different operating systems
+  - os: linux
+  - os: windows
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Try to add a CI job under Windows,
to avoid bugs like #29 