### PR TITLE
prevent clipping of tall equations

### DIFF
--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -5,7 +5,6 @@
 }
 .katex-display > .katex > .katex-html {
     max-width: 100%;
-    overflow-x: auto;
     overflow-y: hidden;
     padding-left: 2px;
     padding-right: 2px;


### PR DESCRIPTION
I'm rendering this equation:
```
    .. math::

        1 - 2 \phi_{i,j} = \frac{4 N^{AA,aa}_{i,j}
                                 + N^{Aa}_{i}
                                 + N^{Aa}_{j}
                                 - 2 N^{Aa,Aa}_{i,j}}
                                {\sum_{s \in S_{i,j}} 4 p_s (1 - p_s)}
```
And the symbols that have both superscripts and subscripts get clipped in the rendering. I've narrowed the bad behavior down to `overflow-x`. I do not really understand why, but the default behavior of `visible` makes the superscripts and subscripts visible.