### PR TITLE
Fix cropping of equation on the top or bottom

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -196,3 +196,24 @@ Some of Maxwell's equations are given in :eq:`gauss-law`,
     :label: maxwell-faraday-equation
 
     \nabla \times \mathbf{E} = -\frac{\partial \mathbf{B}}{\partial t}
+
+
+Fraction
+--------
+
+.. code-block:: rst
+
+        1 - 2 \phi_{i,j} = \frac{4 N^{AA,aa}_{i,j}
+                                 + N^{Aa}_{i}
+                                 + N^{Aa}_{j}
+                                 - 2 N^{Aa,Aa}_{i,j}}
+                                {\sum_{s \in S_{i,j}} 4 p_s (1 - p_s)}
+
+.. math::
+	:label: long fraction line
+
+        1 - 2 \phi_{i,j} = \frac{4 N^{AA,aa}_{i,j}
+                                 + N^{Aa}_{i}
+                                 + N^{Aa}_{j}
+                                 - 2 N^{Aa,Aa}_{i,j}}
+                                {\sum_{s \in S_{i,j}} 4 p_s (1 - p_s)}

--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -9,6 +9,8 @@
     overflow-y: hidden;
     padding-left: 2px;
     padding-right: 2px;
+    padding-bottom: 1px;
+    padding-top: 1px;
 }
 /* Increase margin around equations */
 .katex-display {


### PR DESCRIPTION
Succeeds #33 

Adds another example to the docs and fixes the cropping by adding 1px padding to the top and bottom.