### PR TITLE
Use KaTeX 0.13.11

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@
         \gdef \f #1 {f(#1)}
 
         \f{x} = \int_{-\infty}^\infty
-            \hat \f \xi \,e^{2 \pi i \xi x}
+            \expandafter \hat\f{\xi} \,e^{2 \pi i \xi x}
             \,d\xi
 
 .. math::
@@ -38,5 +38,5 @@
     \gdef \f #1 {f(#1)}
 
     \f{x} = \int_{-\infty}^\infty
-        \hat \f \xi \,e^{2 \pi i \xi x}
+        \expandafter \hat\f{\xi} \,e^{2 \pi i \xi x}
         \,d\xi

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -25,7 +25,7 @@ from sphinx.util.osutil import copyfile
 
 
 __version__ = '0.7.2'
-katex_version = '0.12.0'
+katex_version = '0.13.11'
 filename_css = 'katex-math.css'
 filename_autorenderer = 'katex_autorenderer.js'
 


### PR DESCRIPTION
Switch to KaTeX 0.13.11 and fix related macro definition errors.