### PR TITLE
Let pre-rendering fail if KaTeX fails

### DIFF
--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -85,9 +85,13 @@ def run_katex(latex, *options):
         (cmd, ) + options,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=os.environ.copy()
     )
     stdout, stderr = p.communicate(latex.encode('utf-8'))
+    if p.returncode:
+        msg = 'KaTeX failed with\n: ' + stderr.decode('utf-8')
+        raise RuntimeError(msg)
     return stdout.decode('utf-8')
 
 


### PR DESCRIPTION
Running sphinx with having KaTeX pre-rendering enabled was always succesful even when KaTeX failed with an error message.
The code now checks if KaTeX succeeds and throws a RuntimeError with the original error message otherwise.