### PR TITLE
Remove support for Python 2.7, 3.4, 3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,7 @@ classifiers =
     Programming Language :: Python
     Topic :: Documentation
     Topic :: Utilities
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8


### PR DESCRIPTION
As those Python versins are no longer supported by `pip` we drop them here as well.