### PR TITLE
Add support for Python 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 packages = find:


### PR DESCRIPTION
We test already for Python 3.9, but we haven't added it to `setup.cfg`.