### PR TITLE
Use KaTeX 0.13.11 in docs and all tests

### DIFF
--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -14,6 +14,7 @@ jobs:
       node-version: 10.7
       python-version: 3.6
       sphinx-version: '3.*'
+      katex-version: '0.13.11'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
@@ -33,7 +34,7 @@ jobs:
 
     - name: Prepare KaTeX server
       run: |
-        npm install --global katex
+        npm install --global katex@${{ env.katex-version }}
 
     - name: Set up Sphinx ${{ env.sphinx-version }}
       run: |

--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,11 @@ all configuration entries are listed and their default values are shown.
 .. code-block:: python
 
     katex_css_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css'
+        'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css'
     katex_js_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js'
+        'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js'
     katex_autorender_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.12.0/contrib/auto-render.min.js'
+        'https://cdn.jsdelivr.net/npm/katex@0.13.11/contrib/auto-render.min.js'
     katex_inline = [r'\(', r'\)']
     katex_display = [r'\[', r'\]']
     katex_prerender = False


### PR DESCRIPTION
In the documentation we also have to update the KaTeX version we use as there is no way to include this automatically.
I also restricted the KaTeX pre-rendering test to use the same KaTeX version.