### PR TITLE
Update metadata definitions in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
 name = sphinxcontrib-katex
 author = Hagen Wierstorf
-author-email = hagenw@posteo.de
-home-page = https://github.com/hagenw/sphinxcontrib-katex
+author_email = hagenw@posteo.de
+home_page = https://github.com/hagenw/sphinxcontrib-katex
 description = A Sphinx extension for rendering math in HTML pages
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 keywords = sphinx, latex, katex, math, documentation
 platforms= any
 classifiers =


### PR DESCRIPTION
Changes `name1-name2` to `name1_name2` as `setuptools` was complaining about this.