### PR TITLE
Fix missing version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = sphinxcontrib-katex
+version = attr: package.__version__
 author = Hagen Wierstorf
 author-email = hagenw@posteo.de
 home-page = https://github.com/hagenw/sphinxcontrib-katex


### PR DESCRIPTION
The version of the release `v0.8.0` was set to `0.0.0` as it was not included in `setup.cfg`.