### PR TITLE
Fix reading of version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinxcontrib-katex
-version = attr: package.__version__
+version = attr: sphinxcontrib.katex.__version__
 author = Hagen Wierstorf
 author_email = hagenw@posteo.de
 home_page = https://github.com/hagenw/sphinxcontrib-katex


### PR DESCRIPTION
There was still a typo in `setup.cfg`. This solution I tested now locally and it resulted in the correct version number.