### PR TITLE
Readd manifest to fix compilation of latest docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include *.rst
+global-include requirements.txt
+recursive-include sphinxcontrib *.css
+recursive-include docs *.rst *.py


### PR DESCRIPTION
Compiling the docs on RTD is not able to find the CSS file.
Try to fix this by readding the `MANIFEST.in` file again.