### PR TITLE
TST: re-enable link checks

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,4 +30,4 @@ jobs:
 
     - name: Test for broken links
       run: |
-        # python -m sphinx docs/ docs/_build/ -b linkcheck -W
+        python -m sphinx docs/ docs/_build/ -b linkcheck -W


### PR DESCRIPTION
As the documentation builds are working again on RTD we can re-enable checking for broken links.