### PR TITLE
Increase top padding of equations

### DIFF
--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -10,7 +10,7 @@
     padding-left: 2px;
     padding-right: 2px;
     padding-bottom: 1px;
-    padding-top: 1px;
+    padding-top: 3px;
 }
 /* Increase margin around equations */
 .katex-display {


### PR DESCRIPTION
This increases the top padding of equations from `1px` to `3px` in order to change

![image](https://user-images.githubusercontent.com/173624/118656673-0b513100-b7eb-11eb-9b9b-ed21e51cfa76.png)

to

![image](https://user-images.githubusercontent.com/173624/118656744-1b691080-b7eb-11eb-95d9-ffb1e002b2b4.png)


See also the discussion in https://github.com/hagenw/sphinxcontrib-katex/pull/33