### PR TITLE
Remove unintentional whitespace in prerender mode

### DIFF
--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -92,7 +92,7 @@ def run_katex(latex, *options):
     if p.returncode:
         msg = 'KaTeX failed with\n: ' + stderr.decode('utf-8')
         raise RuntimeError(msg)
-    return stdout.decode('utf-8')
+    return stdout.decode('utf-8').rstrip('\r\n')
 
 
 def html_visit_math(self, node):


### PR DESCRIPTION
The output from katex when pre-rendering can contain a trailing newline, which gets included in the resulting html. This causes an additional space after an inline equation, which is mostly noticeable for equations just before a comma/period.

As an example, this is the result on the inline math snippet from the documentation:

* `katex_prerender = True`, before:
  <img width="505" alt="prerender-before" src="https://user-images.githubusercontent.com/9287484/119665038-40d1cc00-be34-11eb-9087-8ec428260892.png">
* `katex_prerender = True`, after:
  <img width="514" alt="prerender-after" src="https://user-images.githubusercontent.com/9287484/119665051-44fde980-be34-11eb-806c-8e7430c552c2.png">
* `katex_prerender = False`:
  <img width="510" alt="no-prerender" src="https://user-images.githubusercontent.com/9287484/119665068-4a5b3400-be34-11eb-9eb3-575bc0f0c2ed.png">

This fix simply strips all trailing newlines from the katex output.