### PR TITLE
Allow sphinx>=4.0.0 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 namespace_packages =
     sphinxcontrib
 install_requires =
-    sphinx >=1.6, <4.0.0
+    sphinx >=1.6
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
Closes #63.

Removes the Sphinx<4.0.0 limit from `setup.cfg`.