### PR TITLE
CI: use docutils<0.17 for old sphinx versions

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -29,6 +29,7 @@ jobs:
         python -V
         python -m pip install --upgrade pip
         pip install "sphinx==${{ matrix.sphinx-version }}"
+        pip install "docutils<0.17"
 
     - name: Tests
       run: |


### PR DESCRIPTION
Newer versions of `docutils` do not work with older sphinx versions, compare https://github.com/hagenw/sphinxcontrib-katex/runs/4950940111?check_suite_focus=true