### PR TITLE
Depend on jinja2<3.1 to avoid sphinx error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ namespace_packages =
     sphinxcontrib
 install_requires =
     sphinx >=1.6
+    jinja2 <3.1
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
An import behavior from `sphinx` of `jinja2` is causing an error, see https://github.com/sphinx-doc/sphinx/issues/10291.

We use the solution proposed at https://github.com/readthedocs/readthedocs.org/issues/9038#issuecomment-1078964221 and enforce earlier versions of `jinja2`.