### PR TITLE
DOC: add Python version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,7 @@
 sphinxcontrib-katex
 ===================
 
-|tests| |docs| |license|
-
+|tests| |docs| |python-versions| |license|
 
 A `Sphinx extension`_ for rendering math in HTML pages.
 
@@ -31,6 +30,9 @@ as a replacement for the built-in extension `sphinx.ext.mathjax`_, which uses
 .. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
     :target: https://github.com/hagenw/sphinxcontrib-katex/blob/master/LICENSE
     :alt: sphinxcontrib.katex's MIT license
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/sphinxcontrib-katex.svg
+    :target: https://pypi.org/project/sphinxcontrib-katex/
+    :alt: sphinxcontrib-katex's supported Python versions
 
 
 Installation

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 72
-    :end-line: 122
+    :start-line: 74
+    :end-line: 124

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. include:: ../README.rst
-    :end-line: 35
+    :end-line: 37
 
 .. toctree::
     :hidden:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 35
-    :end-line: 54
+    :start-line: 37
+    :end-line: 56

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -1,4 +1,4 @@
 .. _macros:
 
 .. include:: ../README.rst
-    :start-line: 122
+    :start-line: 124

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 54
-    :end-line: 72
+    :start-line: 56
+    :end-line: 74


### PR DESCRIPTION
Add a badge to the README listing supported Python versions and linking to pypi.org.

![image](https://user-images.githubusercontent.com/173624/173068544-d2771f83-4a9a-4c05-bc03-d324f9a2d739.png)
