### PR TITLE
DOC: adjust test badge to point to Github Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ as a replacement for the built-in extension `sphinx.ext.mathjax`_, which uses
 .. _sphinx.ext.mathjax:
     https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py
 
-.. |tests| image:: https://travis-ci.org/hagenw/sphinxcontrib-katex.svg?branch=master
-    :target: https://travis-ci.org/hagenw/sphinxcontrib-katex/
-    :alt: sphinxcontrib.katex on TravisCI
+.. |tests| image:: https://github.com/hagenw/sphinxcontrib-katex/workflows/Test/badge.svg
+    :target: https://github.com/hagenw/sphinxcontrib-katex/actions?query=workflow%3ATest
+    :alt: Test status
 .. |docs| image:: https://readthedocs.org/projects/sphinxcontrib-katex/badge/
     :target: https://sphinxcontrib-katex.readthedocs.io/
     :alt: sphinxcontrib.katex's documentation on Read the Docs


### PR DESCRIPTION
The test badge was still showing results from Travis CI, but we are now using Github Actions for the tests.

![image](https://user-images.githubusercontent.com/173624/173069566-bd8c1ebf-ab4e-44a2-9603-1c17155ab530.png)
