### PR TITLE
Use KaTeX 0.16.0

### DIFF
--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -14,7 +14,7 @@ jobs:
       node-version: 10.7
       python-version: 3.8
       sphinx-version: '3.*'
-      katex-version: '0.13.11'
+      katex-version: '0.16.0'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]

--- a/README.rst
+++ b/README.rst
@@ -82,11 +82,11 @@ all configuration entries are listed and their default values are shown.
 .. code-block:: python
 
     katex_css_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css'
+        'https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css'
     katex_js_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js'
+        'https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js'
     katex_autorender_path = \
-        'https://cdn.jsdelivr.net/npm/katex@0.15.2/contrib/auto-render.min.js'
+        'https://cdn.jsdelivr.net/npm/katex@0.16.0/contrib/auto-render.min.js'
     katex_inline = [r'\(', r'\)']
     katex_display = [r'\[', r'\]']
     katex_prerender = False

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -25,7 +25,7 @@ from sphinx.util.osutil import copyfile
 
 
 __version__ = '0.8.6'
-katex_version = '0.15.2'
+katex_version = '0.16.0'
 filename_css = 'katex-math.css'
 filename_autorenderer = 'katex_autorenderer.js'
 


### PR DESCRIPTION
Uses https://github.com/KaTeX/KaTeX/releases/tag/v0.16.0 as new default.