### PR TITLE
Add script to update KaTeX version

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,6 +67,20 @@ request on Github_.
 .. _Travis: https://travis-ci.org/hagenw/sphinxcontrib-katex/
 
 
+Updating to a new KaTeX version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``sphinxcontrib.katex`` is bond to fixed KaTeX versions.
+To update the package to a new KaTeX version,
+execute:
+
+.. code-block:: bash
+
+    bash update-katex-version.sh
+
+and commit the resulting changes.
+
+
 Creating a New Release
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -10,12 +10,16 @@ CURRENT_VERSION=${CURRENT_VERSION//\'/}
 echo "Current KaTeX version: ${CURRENT_VERSION}"
 echo "New KaTeX version: ${NEW_VERSION}"
 
-if [ ${NEW_VERSION} -lt ${CURRENT_VERSION} ]; then
+# Function to compare version numbers,
+# https://www.baeldung.com/linux/compare-dot-separated-version-string
+function version { printf "%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+
+if [ $(version ${NEW_VERSION}) -lt $(version ${CURRENT_VERSION}) ]; then
     echo "Something went wrong as current version is newer"
     exit 1
 fi
 
-if [ ${NEW_VERSION} -eq ${CURRENT_VERSION} ]; then
+if [ $(version ${NEW_VERSION}) -eq $(version ${CURRENT_VERSION}) ]; then
     echo "Versions are the same."
     exit 0
 fi

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -11,7 +11,7 @@ echo "Current KaTeX version: ${CURRENT_VERSION}"
 echo "New KaTeX version: ${NEW_VERSION}"
 
 # Download JS file
-curl -s https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist/katex.js --output sphinxcontrib/katex.js
+curl -s https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist/katex.min.js --output sphinxcontrib/katex.min.js
 
 # Update Python file
 sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}'" sphinxcontrib/katex.py

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -10,8 +10,23 @@ CURRENT_VERSION=${CURRENT_VERSION//\'/}
 echo "Current KaTeX version: ${CURRENT_VERSION}"
 echo "New KaTeX version: ${NEW_VERSION}"
 
-# Download JS file
-curl -s https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist/katex.min.js --output sphinxcontrib/katex.min.js
+if [ ${NEW_VERSION} -lt ${CURRENT_VERSION} ]; then
+    echo "Something went wrong as current version is newer"
+    exit 1
+fi
+
+if [ ${NEW_VERSION} -eq ${CURRENT_VERSION} ]; then
+    echo "Versions are the same."
+    exit 0
+fi
+
+KATEX_URL="https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist"
+
+# Download JS files
+echo "Updating katex.min.js"
+curl -s ${KATEX_URL}/katex.min.js --output sphinxcontrib/katex.min.js
+echo "Updating auto-render.min.js"
+curl -s ${KATEX_URL}/auto-render.min.js --output sphinxcontrib/auto-render.min.js
 
 # Update Python file
 sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}'" sphinxcontrib/katex.py

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+NEW_VERSION=$(curl -s 'https://registry.npmjs.org/katex' | jq '.["dist-tags"]["latest"]')
+CURRENT_VERSION=$(awk '/katex_version =/{print $3}' sphinxcontrib/katex.py)
+
+# Remove "" and '' around version
+NEW_VERSION=${NEW_VERSION//\"/}
+CURRENT_VERSION=${CURRENT_VERSION//\'/}
+
+echo "Current KaTeX version: ${CURRENT_VERSION}"
+echo "New KaTeX version: ${NEW_VERSION}"
+
+# Download JS file
+curl -s https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist/katex.js --output sphinxcontrib/katex.js
+
+# Update Python file
+sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}'" sphinxcontrib/katex.py
+
+# Update README
+sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/" README.rst

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -30,7 +30,7 @@ KATEX_URL="https://cdn.jsdelivr.net/npm/katex@${NEW_VERSION}/dist"
 echo "Updating katex.min.js"
 curl -s ${KATEX_URL}/katex.min.js --output sphinxcontrib/katex.min.js
 echo "Updating auto-render.min.js"
-curl -s ${KATEX_URL}/auto-render.min.js --output sphinxcontrib/auto-render.min.js
+curl -s ${KATEX_URL}/contrib/auto-render.min.js --output sphinxcontrib/auto-render.min.js
 
 # Update Python file
 sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}'" sphinxcontrib/katex.py


### PR DESCRIPTION
Closes #79 

This adds a script for updating to a newer KaTeX version.

Execute the script with:
```bash
$ bash update-katex-version.sh
```
in the root of the repo and if a newer version can be found it will
* download `sphinxcontrib/katex.min.js`
* download `sphinxcontrib/auto-render.min.js`
* update the version number in `sphinxcontrib/katex.py`
* update the version number in `README.rst`