### PR TITLE
DOC: fix instructions for pre-rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,14 +44,12 @@ To install ``sphinxcontrib.katex`` into your Python virtual environment run:
 
     $ pip install sphinxcontrib-katex
 
-If you want to pre-render the math by running Javascript on your server instead
-of running it in the browsers of the users, you have to install ``katex`` on
-your server and add it to your path:
+If you want to pre-render the math
+by running Javascript on your server
+instead of running it in the browsers of the users,
+you have to install nodejs_.
 
-.. code-block:: bash
-
-    $ npm install katex
-    $ PATH="${PATH}:$(pwd)/node_modules/.bin"
+.. _nodejs: https://nodejs.org/
 
 
 Usage
@@ -63,13 +61,17 @@ In ``conf.py`` of your Sphinx project, add the extension with:
 
     extensions = ['sphinxcontrib.katex']
 
-For enable server side pre-rendering add in addition (node js installation needed):
+For enable server side pre-rendering
+add in addition
+(nodejs_ installation needed):
 
 .. code-block:: python
 
     katex_prerender = True
 
 See the Configuration section for all available settings.
+
+.. _nodejs: https://nodejs.org/
 
 
 Configuration

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 74
-    :end-line: 122
+    :start-line: 76
+    :end-line: 124

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
     :start-line: 37
-    :end-line: 56
+    :end-line: 54

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -1,4 +1,4 @@
 .. _macros:
 
 .. include:: ../README.rst
-    :start-line: 122
+    :start-line: 124

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 56
-    :end-line: 74
+    :start-line: 54
+    :end-line: 76


### PR DESCRIPTION
For the new server side pre-rendering introduced in (https://github.com/hagenw/sphinxcontrib-katex/pull/69) we no longer have to install `katex` using `npm`, but just require that `nodejs` is available.

![image](https://user-images.githubusercontent.com/173624/185581576-945a1ccf-305e-4dd9-9d98-968e279798a8.png)

![image](https://user-images.githubusercontent.com/173624/185581630-e5a47dd7-0545-4dff-8d56-8a89702d34f6.png)
