### PR TITLE
Make sure we use font-size of document

### DIFF
--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -2,6 +2,8 @@
  * See: https://github.com/Khan/KaTeX/issues/327 */
 .katex-display > .katex {
     max-width: 100%;
+    /* Ensure we use same font-size as rest of document */
+    font-size: 100%;
 }
 .katex-display > .katex > .katex-html {
     max-width: 100%;


### PR DESCRIPTION
Before it could happen that we match not very well the font size of the rest of the HTML page, e.g.

![image](https://user-images.githubusercontent.com/173624/203921995-32d00ac5-ff05-4993-a41e-cae603461fe2.png)

this changes this by requiring the same font size

![image](https://user-images.githubusercontent.com/173624/203922058-fee73dee-afe4-4daf-8ca0-34f607f073bb.png)
