### PR TITLE
TST: update versions of used Actions

### DIFF
--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -20,15 +20,15 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ env.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ env.node-version }}
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,10 +15,10 @@ jobs:
       python-version: 3.8
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -18,10 +18,10 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -17,10 +17,10 @@ jobs:
         sphinx-version: [ 1.6.7, 1.8.6, 2.4.5, 3.5.4, 4.5.0 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python-version }}
 


### PR DESCRIPTION
We have deprecated actions, compare https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To fix I switched to

* actions/checkout@v3
* actions/setup-node@v3
* actions/setup-python@v4