### PR TITLE
Revert smaller scaling of math font

### DIFF
--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -1,7 +1,3 @@
-/* Ensure we use same font-size as rest of document */
-.katex {
-    font-size: 100%;
-}
 /* Responsives: make equations scrollable on small screens.
  * See: https://github.com/Khan/KaTeX/issues/327 */
 .katex-display > .katex {


### PR DESCRIPTION
As written in the [KaTeX docs](https://katex.org/docs/font.html) it is on purpose that the math font size is 1.21 times larger:

![image](https://user-images.githubusercontent.com/173624/203953134-8d5eb71d-f15a-4152-9f03-ba74ed5151ae.png)

So I think we shouldn't enforce a different behavior here. if the user wants a different behavior she/he has to write custom CSS.