### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Flake8
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,6 +24,39 @@ This way, your installation always stays up-to-date, even if you pull new
 changes from the Github repository.
 
 
+Coding Convention
+^^^^^^^^^^^^^^^^^
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install pre-commit  # consider system wide installation
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,9 @@ copyright = '2017-' + year + ' ' + author
 
 needs_sphinx = '1.6'   # minimal sphinx version
 extensions = [
-        'sphinx.ext.autodoc',
-        'sphinx.ext.viewcode',
-        'sphinxcontrib.katex',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinxcontrib.katex',
 ]
 master_doc = 'index'
 source_suffix = '.rst'
@@ -26,7 +26,8 @@ exclude_patterns = ['_build']
 # release = version
 try:
     release = subprocess.check_output(
-            ['git', 'describe', '--tags', '--always'])
+        ['git', 'describe', '--tags', '--always']
+    )
     release = release.decode().strip()
 except Exception:
     release = '<unknown>'
@@ -62,13 +63,15 @@ html_theme_options = {
 latex_macros += r'\usepackage{arydshln}'
 
 latex_elements = {
-        'papersize': 'a4paper',
-        'pointsize': '10pt',
-        'preamble': latex_macros,  # command definitions
-        'figure_align': 'htbp',
-        'sphinxsetup': ('TitleColor={rgb}{0,0,0}, '
-                        'verbatimwithframe=false, '
-                        'VerbatimColor={rgb}{.96,.96,.96}'),
+    'papersize': 'a4paper',
+    'pointsize': '10pt',
+    'preamble': latex_macros,  # command definitions
+    'figure_align': 'htbp',
+    'sphinxsetup': (
+        'TitleColor={rgb}{0,0,0}, '
+        'verbatimwithframe=false, '
+        'VerbatimColor={rgb}{.96,.96,.96}'
+    ),
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,14 @@ install_requires =
     sphinx >=1.6
 python_requires = >=3.7
 
-[tool:pytest]
-addopts = --flake8
-xfail_strict = true
-
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+    node_modules,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -13,13 +13,11 @@
 import atexit
 import json
 import os
-import platform
 import re
 import shutil
 from docutils import nodes
 from tempfile import mkdtemp
 from textwrap import dedent
-import subprocess
 import socket
 import struct
 import tempfile
@@ -121,9 +119,11 @@ def html_visit_math(self, node):
     if self.builder.config.katex_prerender:
         self.body.append(render_latex(get_latex(node)))
     else:
-        self.body.append(self.builder.config.katex_inline[0] +
-                         self.encode(get_latex(node)) +
-                         self.builder.config.katex_inline[1])
+        self.body.append(
+            self.builder.config.katex_inline[0]
+            + self.encode(get_latex(node))
+            + self.builder.config.katex_inline[1]
+        )
 
     self.body.append('</span>')
     raise nodes.SkipNode
@@ -156,8 +156,11 @@ def html_visit_displaymath(self, node):
 
 
 def builder_inited(app):
-    if not (app.config.katex_js_path and app.config.katex_css_path and
-            app.config.katex_autorender_path):
+    if not (
+            app.config.katex_js_path
+            and app.config.katex_css_path
+            and app.config.katex_autorender_path
+    ):
         raise ExtensionError('KaTeX paths not set')
     # Sphinx 1.8 renamed `add_stylesheet` to `add_css_file`
     # and `add_javascript` to `add_js_file`.
@@ -524,7 +527,10 @@ class KaTeXServer:
                         # of the whole timeout again
                         self.sock.settimeout(timeout - elapsed)
 
-                n_received = self.sock.recv_into(view[received:length], remaining)
+                n_received = self.sock.recv_into(
+                    view[received:length],
+                    remaining,
+                )
                 received += n_received
                 remaining -= n_received
 


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.