### PR TITLE
Convert timeout_error to classmethod

### DIFF
--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -363,7 +363,7 @@ class KaTeXServer:
     STOP_TIMEOUT = 0.1
 
     @classmethod
-    def timeout_error(self, timeout):
+    def timeout_error(cls, timeout):
         message = STARTUP_TIMEOUT_EXPIRED.format(timeout)
         return KaTeXError(message)
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -362,7 +362,7 @@ class KaTeXServer:
     # wait for the server to stop in seconds
     STOP_TIMEOUT = 0.1
 
-    @staticmethod
+    @classmethod
     def timeout_error(self, timeout):
         message = STARTUP_TIMEOUT_EXPIRED.format(timeout)
         return KaTeXError(message)


### PR DESCRIPTION
timeout_error is called multiple times with the class context; arguably could leave it as static method and remove the cls. prefix from the other calls but keeping conservative.

Fixes #98