### PR TITLE
DOC: fix typo in usage section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ In ``conf.py`` of your Sphinx project, add the extension with:
 
     extensions = ['sphinxcontrib.katex']
 
-For enable server side pre-rendering
+To enable server side pre-rendering
 add in addition
 (nodejs_ installation needed):
 


### PR DESCRIPTION
Fixes a small typo in the usage documentation:

![image](https://github.com/hagenw/sphinxcontrib-katex/assets/173624/b18f16ec-a5cb-48d4-934d-eb5bab1ad672)
