### PR TITLE
DOC: reduce gray color saturation of HTML theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,7 +1,35 @@
+/* Reduce saturation of main text color */
 body {
     color: #313131;
 }
 
+/* Reduce saturation of horizontal separation lines */
+#topbar {
+    border-bottom: #f1f1f1 solid 1px;
+}
+footer, div.articleComments {
+    border-top: #f1f1f1 solid 1px;
+}
+hr.docutils {
+    border-top: #f1f1f1 solid 1px;
+}
+
+/* Reduce saturation of footer color */
+footer {
+    color: #888;
+}
+
+/* Reduce saturation of code highlight background */
+.highlight {
+    background: #f6f8fa;
+}
+
+/* Reduce saturation of sidebar background */
+div.sphinxsidebar {
+    background-color: #fbfbfb;
+}
+
+/* Remove underline from external links */
 a.external {
     text-decoration: none;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,8 @@ htmlhelp_basename = project
 html_theme = 'insipid'
 html_permalinks_icon = '#'
 html_copy_source = False
+html_show_sourcelink = False
+html_use_index = False
 html_theme_options = {
     'right_buttons': [
         'fullscreen-button.html',


### PR DESCRIPTION
This tweaks the HTML sphinx theme by reducing the color saturation for:

* horizontal separation lines as in the footer and topbar
* code highlight blocks
* text in footer
* background of sidebar

In addition, it removes the source link from the footer and the "General Index" entry from the sidebar.