### PR TITLE
DOC: ensure hovered links show underline

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -33,3 +33,6 @@ div.sphinxsidebar {
 a.external {
     text-decoration: none;
 }
+a.external:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Make sure external links show an underline when hovered by the mouse.