### PR TITLE
DOC: remove test badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 sphinxcontrib-katex
 ===================
 
-|tests| |docs| |python-versions| |license|
+|docs| |python-versions| |license|
 
 A `Sphinx extension`_ for rendering math in HTML pages.
 
@@ -21,9 +21,6 @@ as a replacement for the built-in extension `sphinx.ext.mathjax`_, which uses
 .. _sphinx.ext.mathjax:
     https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/mathjax.py
 
-.. |tests| image:: https://github.com/hagenw/sphinxcontrib-katex/workflows/Test/badge.svg
-    :target: https://github.com/hagenw/sphinxcontrib-katex/actions?query=workflow%3ATest
-    :alt: Test status
 .. |docs| image:: https://readthedocs.org/projects/sphinxcontrib-katex/badge/
     :target: https://sphinxcontrib-katex.readthedocs.io/
     :alt: sphinxcontrib.katex's documentation on Read the Docs

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 76
-    :end-line: 124
+    :start-line: 73
+    :end-line: 121

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. include:: ../README.rst
-    :end-line: 37
+    :end-line: 34
 
 .. toctree::
     :hidden:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 37
-    :end-line: 54
+    :start-line: 34
+    :end-line: 51

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -1,4 +1,4 @@
 .. _macros:
 
 .. include:: ../README.rst
-    :start-line: 124
+    :start-line: 121

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 54
-    :end-line: 76
+    :start-line: 51
+    :end-line: 73


### PR DESCRIPTION
In https://github.com/hagenw/sphinxcontrib-katex/pull/42 we split up the tests into several Github actions, which means it makes no longer sense to show a single test badge (and the current test badge was still pointing to the removed "Test" action).
This pull request simply removes the badge from the README.

![image](https://github.com/hagenw/sphinxcontrib-katex/assets/173624/09a42636-b36e-4d52-babf-5809fc82535f)
