### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
       sphinx-version: '5.*'
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Topic :: Documentation
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
Python 3.7 has reached its [end of life](https://endoflife.date/python) at 2023/06/27, so we remove support for it.