### PR TITLE
CI: use Python 3.10 as default version

### DIFF
--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -11,10 +11,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      node-version: 16.0
-      python-version: 3.8
+      node-version: 20.0
+      python-version: 3.10
       sphinx-version: '3.*'
-      katex-version: '0.16.0'
+      katex-version: '0.16.9'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -11,8 +11,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      node-version: 20.0
-      python-version: 3.10
+      node-version: '20.0'
+      python-version: '3.10'
       sphinx-version: '5.*'
       katex-version: '0.16.9'
     strategy:

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       node-version: 20.0
       python-version: 3.10
-      sphinx-version: '3.*'
+      sphinx-version: '5.*'
       katex-version: '0.16.9'
     strategy:
       matrix:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       sphinx-version: '3.*'
-      python-version: 3.8
+      python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      sphinx-version: '3.*'
+      sphinx-version: '5.*'
       python-version: '3.10'
 
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      sphinx-version: '3.*'
+      sphinx-version: '5.*'
       python-version: 3.10
     strategy:
       matrix:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       sphinx-version: '5.*'
-      python-version: 3.10
+      python-version: '3.10'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       sphinx-version: '3.*'
-      python-version: 3.8
+      python-version: 3.10
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/sphinx-legacy.yml
+++ b/.github/workflows/sphinx-legacy.yml
@@ -1,4 +1,4 @@
-name: Sphinx
+name: Sphinx legacy
 
 on:
   push:
@@ -11,10 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      python-version: '3.10'
+      python-version: '3.8'
     strategy:
       matrix:
-        sphinx-version: [ '5.3.0', '6.2.1', '7.*' ]
+        sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ jobs:
       python-version: '3.10'
     strategy:
       matrix:
-        sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0' ]
+        sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0', '5.3.0', '6.2.1', '7.*' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ jobs:
       python-version: '3.10'
     strategy:
       matrix:
-        sphinx-version: [ '5.3.0', '6.2.1', '7.*' ]
+        sphinx-version: [ '5.3.0' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      python-version: 3.8
+      python-version: '3.10'
     strategy:
       matrix:
         sphinx-version: [ 1.6.7, 1.8.6, 2.4.5, 3.5.4, 4.5.0 ]

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ jobs:
       python-version: '3.10'
     strategy:
       matrix:
-        sphinx-version: [ 1.6.7, 1.8.6, 2.4.5, 3.5.4, 4.5.0 ]
+        sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -33,7 +33,13 @@ echo "Updating auto-render.min.js"
 curl -s ${KATEX_URL}/contrib/auto-render.min.js --output sphinxcontrib/auto-render.min.js
 
 # Update Python file
+echo "Updating katex.py"
 sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}'" sphinxcontrib/katex.py
 
 # Update README
+echo "Updating README.rst"
 sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/" README.rst
+
+# Update github Action for pre-rendering
+echo "Updating .github/workflows/katex.yml"
+sed -i "s/katex-version: '${CURRENT_VERSION}'/katex-version: '${NEW_VERSION}'/" .github/workflows/katex.yml


### PR DESCRIPTION
* Updates all github Actions that use a single Python version to use Python 3.10
* Updates the nodejs version to 20.0
* Extends `update-katex-version.sh` script to also update the KaTeX version in `.github/workflows/katex.yml`
* Update sphinx version to 5.* for all tests that use a fixed sphinx version and Python 3.10
* Expand tested sphinx versions by 5.3.0
* Split sphinx action into two as old versions of sphinx require Python 3.8