### PR TITLE
TST: test for sphinx versions 6.2.1, 7.*

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ jobs:
       python-version: '3.10'
     strategy:
       matrix:
-        sphinx-version: [ '5.3.0' ]
+        sphinx-version: [ '5.3.0', '6.2.1', '7.*' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -29,8 +29,6 @@ jobs:
         python -V
         python -m pip install --upgrade pip
         pip install "sphinx==${{ matrix.sphinx-version }}"
-        pip install "docutils<0.17"
-        pip install "jinja2<3.1"
 
     - name: Tests
       run: |


### PR DESCRIPTION
This adjusts the sphinx tests to also test for versions 6.2.1 and 7.* and no longer restrict the requirements on `jinja2` and `docutils`.