### PR TITLE
DOC: add read the docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    nodejs: "20"
+  commands:
+    - npm install --global "katex@0.16.9"
+    - python -m sphinx docs $READTHEDOCS_OUTPUT -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
+
+sphinx:
+  configuration: docs/conf.py
+  # Fail on all warnings to avoid broken references
+  fail_on_warning: true
+
+formats:
+   - pdf
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -43,3 +43,7 @@ sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/" README.rst
 # Update github Action for pre-rendering
 echo "Updating .github/workflows/katex.yml"
 sed -i "s/katex-version: '${CURRENT_VERSION}'/katex-version: '${NEW_VERSION}'/" .github/workflows/katex.yml
+
+# Update Read The Docs configuration
+echo "Updating .readthedocs.yaml"
+sed -i "s/katex@${CURRENT_VERSION}/katex@${NEW_VERSION}/" .readthedocs.yaml


### PR DESCRIPTION
As Read The Docs now requires configuration files in order to build the docs, we add one.
We also enable pre-rendering with it and extend `update-katex-version.sh` to also update the used KaTeX version inside the RTD config file.