### PR TITLE
DOC: ensure RTD build uses config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     - npm install --global "katex@0.16.9"
     - pip install .
     - pip install -r docs/requirements.txt
-    - python -m sphinx docs $READTHEDOCS_OUTPUT/html -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
+    - python -m sphinx docs $READTHEDOCS_OUTPUT/html -b html -W -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
In the RTD config file we had disabled the usage of the config file. This pull request re-enables the config file to select the desired theme for the documentation.