### PR TITLE
Fix building of Python package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build virtualenv
+
+    # PyPI package
+    - name: Build
+      run: |
+        python -m build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build package
+name: Python package
 
 on:
   push:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,9 +160,6 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
-where = ['.']
-# include = ["sphinxcontrib", "sphinxcontrib.katex"]
-# find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools.dynamic]
 version = {attr = 'sphinxcontrib.katex.__version__'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,10 @@ convention = 'google'
 # ----- setuptools --------------------------------------------------------
 #
 # Find all (sub-)modules of the Python package
-[tool.setuptools.packages]
-find = {namespaces = false}  # Disable implicit namespaces
+[tool.setuptools.packages.find]
+where = ['.']
+include = ["sphinxcontrib.*"]
+# find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools.dynamic]
 version = {attr = 'sphinxcontrib.katex.__version__'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ convention = 'google'
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
 where = ['.']
-include = ["sphinxcontrib", "sphinxcontrib.katex"]
+# include = ["sphinxcontrib", "sphinxcontrib.katex"]
 # find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ convention = 'google'
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
 where = ['.']
-include = ["sphinxcontrib.*"]
+include = ["sphinxcontrib", "sphinxcontrib.katex"]
 # find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Fix publication of Python package with `pyproject.toml`.
It also adds a test for building the Python package.

The previous configuration has failed with https://github.com/hagenw/sphinxcontrib-katex/actions/runs/6495362329/job/17640167421.