### PR TITLE
Version number update in Action no longer needed

### DIFF
--- a/update-katex-version.sh
+++ b/update-katex-version.sh
@@ -40,10 +40,6 @@ sed -i "/katex_version = '${CURRENT_VERSION}'/c\\katex_version = '${NEW_VERSION}
 echo "Updating README.rst"
 sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/" README.rst
 
-# Update github Action for pre-rendering
-echo "Updating .github/workflows/katex.yml"
-sed -i "s/katex-version: '${CURRENT_VERSION}'/katex-version: '${NEW_VERSION}'/" .github/workflows/katex.yml
-
 # Update Read The Docs configuration
 echo "Updating .readthedocs.yaml"
 sed -i "s/katex@${CURRENT_VERSION}/katex@${NEW_VERSION}/" .readthedocs.yaml


### PR DESCRIPTION
As we removed installing KaTeX in the action to test the pre-rendering in #124, we also do no longer need to update the Action definition, when using another version of KaTeX. 