### PR TITLE
CI: update actions to switch to Node.js 20

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,10 +14,10 @@ jobs:
       python-version: '3.10'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -19,15 +19,15 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ env.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.node-version }}
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,10 +15,10 @@ jobs:
       python-version: '3.10'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v4

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -18,10 +18,10 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Create release on Github
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sphinx-legacy.yml
+++ b/.github/workflows/sphinx-legacy.yml
@@ -17,10 +17,10 @@ jobs:
         sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -17,10 +17,10 @@ jobs:
         sphinx-version: [ '5.3.0', '6.2.1', '7.*' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.python-version }}
 


### PR DESCRIPTION
As discussed at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, we need to update all Github Actions that are still using Node.js 16.

We fix this here by updating to:

* actions/checkout@v4
* actions/cache@v4
* actions/setup-node@v4
* actions/setup-python@v5
* softprops/action-gh-release@v2