### PR TITLE
Use katex_js_path when pre-rendering

### DIFF
--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.non.js -D katex_prerender=1 -vvv
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.min.js -D katex_prerender=1 -vvv

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path="katex.non.js" -D katex_prerender=1
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path="katex.non.js" -D katex_prerender=1 -vvv

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex,katex_js_path="katex.non.js" -D katex_prerender=1

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.min.js -D katex_prerender=1 -vvv
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=./katex.min.js -D katex_prerender=1 -vvv

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.min.js -D katex_prerender=1 -vvv
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path="katex.non.js" -D katex_prerender=1 -vvv
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.non.js -D katex_prerender=1 -vvv

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex,katex_js_path="katex.non.js" -D katex_prerender=1
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path="katex.non.js" -D katex_prerender=1

--- a/.github/workflows/katex.yml
+++ b/.github/workflows/katex.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Tests
       run: |
-        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=./katex.min.js -D katex_prerender=1 -vvv
+        python -m sphinx docs docs/_build/ -b html -W -C -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_js_path=katex.min.js -D katex_prerender=1 -vvv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,16 @@ builtin = 'clear,rare,informal,names'
 skip = '*.js,./sphinxcontrib_katex.egg-info,./build'
 
 
+# ----- pytest ------------------------------------------------------------
+#
+[tool.pytest.ini_options]
+cache_dir = '.cache/pytest'
+xfail_strict = true
+addopts = '''
+    --ignore=docs/
+'''
+
+
 # ----- ruff --------------------------------------------------------------
 #
 [tool.ruff]

--- a/sphinxcontrib/katex-server.js
+++ b/sphinxcontrib/katex-server.js
@@ -9,7 +9,7 @@ let port = null;
 // without `.js` at the end.
 // The default points to the one bundled with the extension.
 // Otherwise the file provided with the `katex_js_path`
-// config setting is used.
+// config setting is used. The path must start with "./".
 let katex_path = "./katex.min";
 process.argv.forEach(function(arg) {
     if (value == "katex_path") {

--- a/sphinxcontrib/katex-server.js
+++ b/sphinxcontrib/katex-server.js
@@ -5,9 +5,11 @@ let value = null;
 let katex_options = {};
 let socket = null;
 let port = null;
-// this is the downloaded katex javascript library.
-// need to keep it updated
-// path to the downloaded katex javascript library `katex.min.js`.
+// Default path to the KaTeX Javascript library
+// without `.js` at the end.
+// The default points to the one bundled with the extension.
+// Otherwise the file provided with the `katex_js_path`
+// config setting is used.
 let katex_path = "./katex.min";
 process.argv.forEach(function(arg) {
     if (value == "katex_path") {

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -389,15 +389,12 @@ class KaTeXServer:
             # KaTeX will be included inside katex-server.js
             # using `require()`,
             # which needs the relative path to `katex.min.js`
-            # without `.js` at the end
-            print(f"DEBUG: giveb {cls.KATEX_PATH=}")
+            # without `.js` at the end.
+            # The default is to use `./katex.min.js`
             katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]
             # relative path had to start with `"./"` for `require()`
-            katex_path = os.path.join("./../sphinxcontrib/", katex_path)
-            print(f"DEBUG: add {katex_path=}")
+            katex_path = os.path.join("./sphinxcontrib/", katex_path)
             cmd.extend(["--katex", katex_path])
-        else:
-            print(f"DEBUG: add {cls.KATEX_PATH=}")
 
         return cmd
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -391,16 +391,13 @@ class KaTeXServer:
             # which needs the relative path to `katex.min.js`
             # without `.js` at the end.
             # The default is to use `./katex.min.js`
-            print(f"{str(cls.katex_path)=}")
-            print(f"{os.path.abspath(str(cls.katex_path))=}")
-            katex_path = os.path.relpath(
-                os.path.abspath(str(cls.katex_path)),
-                start=SRC_DIR,
-            )
+            katex_path = str(cls.katex_path)
+            if not os.path.isabs(katex_path):
+                katex_path = os.path.abspath(os.path.join(SRC_DIR, katex_path))
+            katex_path = os.path.relpath(katex_path, start=SRC_DIR)
+
             # Relative path has to start with `"./"` for `require()`
             katex_path = os.path.join("./", katex_path)
-            print(f"{katex_path=}")
-            print(f"{os.path.join(SRC_DIR, katex_path)=}")
             if not os.path.exists(os.path.join(SRC_DIR, katex_path)):
                 raise ValueError(
                     f"KaTeX Javascript library could not be found at {katex_path}."

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -387,6 +387,8 @@ class KaTeXServer:
         if KATEX_PATH:
             print(f"DEBUG: add {KATEX_PATH=}")
             cmd.extend(["--katex", str(KATEX_PATH)])
+        else:
+            print(f"DEBUG: add {KATEX_PATH=}")
 
         return cmd
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -391,9 +391,14 @@ class KaTeXServer:
             # which needs the relative path to `katex.min.js`
             # without `.js` at the end.
             # The default is to use `./katex.min.js`
-            katex_path = os.path.relpath(str(cls.katex_path))[:-3]
-            # relative path had to start with `"./"` for `require()`
+            katex_path = os.path.relpath(str(cls.katex_path))
+            # Relative path has to start with `"./"` for `require()`
             katex_path = os.path.join("./", katex_path)
+            if not os.path.exists(katex_path):
+                raise ValueError(
+                    f"KaTeX Javascript library could not be found at {katex_path}."
+                )
+            katex_path = katex_path[:-3]  # remove `.js`
             cmd.extend(["--katex", katex_path])
 
         return cmd

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -56,8 +56,6 @@ KATEX_DEFAULT_OPTIONS = {
     "throwOnError": False
 }
 
-KATEX_PATH = None
-
 # How long to wait for the render server to start in seconds
 STARTUP_TIMEOUT = 5.0
 
@@ -361,6 +359,9 @@ class KaTeXServer:
     # Message length is 32-bit little-endian integer
     LENGTH_STRUCT = struct.Struct("<i")
 
+    # Path to KaTeX javascript file
+    KATEX_PATH = None
+
     # global instance
     KATEX_SERVER = None
 
@@ -373,8 +374,8 @@ class KaTeXServer:
         message = STARTUP_TIMEOUT_EXPIRED.format(timeout)
         return KaTeXError(message)
 
-    @staticmethod
-    def build_command(socket=None, port=None):
+    @classmethod
+    def build_command(cls, socket=None, port=None):
         """KaTeX node build command."""
         cmd = [NODEJS_BINARY, SCRIPT_PATH]
 
@@ -384,11 +385,11 @@ class KaTeXServer:
         if port is not None:
             cmd.extend(["--port", str(port)])
 
-        if KATEX_PATH:
-            print(f"DEBUG: add {KATEX_PATH=}")
-            cmd.extend(["--katex", str(KATEX_PATH)])
+        if cls.KATEX_PATH is not None:
+            print(f"DEBUG: add {cls.KATEX_PATH=}")
+            cmd.extend(["--katex", str(cls.KATEX_PATH)])
         else:
-            print(f"DEBUG: add {KATEX_PATH=}")
+            print(f"DEBUG: add {cls.KATEX_PATH=}")
 
         return cmd
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -393,7 +393,7 @@ class KaTeXServer:
             # The default is to use `./katex.min.js`
             katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]
             # relative path had to start with `"./"` for `require()`
-            katex_path = os.path.join("./sphinxcontrib/", katex_path)
+            katex_path = os.path.join("./", katex_path)
             cmd.extend(["--katex", katex_path])
 
         return cmd

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -356,8 +356,8 @@ class KaTeXError(Exception):
 class KaTeXServer:
     """Manages and communicates with an instance of the render server."""
 
-    length_struct = struct.Struct("<i")
-    """Message length (32-bit little-endian integer)."""
+    LENGTH_STRUCT = struct.Struct("<i")
+    """Message length for 32-bit little-endian integer."""
 
     katex_path = None
     """Path to KaTeX javascript file."""
@@ -365,7 +365,7 @@ class KaTeXServer:
     katex_server = None
     """Global instance of KaTeX server."""
 
-    stop_timeout = 0.1
+    STOP_TIMEOUT = 0.1
     """Wait time for the server to stop in seconds."""
 
     @classmethod
@@ -513,7 +513,7 @@ class KaTeXServer:
         self.sock.close()
         try:
             self.process.terminate()
-            self.process.wait(timeout=self.stop_timeout)
+            self.process.wait(timeout=self.STOP_TIMEOUT)
         except TimeoutExpired:
             self.process.kill()
         shutil.rmtree(self.rundir)
@@ -530,12 +530,12 @@ class KaTeXServer:
         # Send the request
         request_bytes = json.dumps(request).encode("utf-8")
         length = len(request_bytes)
-        self.sock.sendall(self.length_struct.pack(length))
+        self.sock.sendall(self.LENGTH_STRUCT.pack(length))
         self.sock.sendall(request_bytes)
 
         # Read the amount of bytes we are about to receive
-        size = self.sock.recv(self.length_struct.size)
-        length = self.length_struct.unpack(size)[0]
+        size = self.sock.recv(self.LENGTH_STRUCT.size)
+        length = self.LENGTH_STRUCT.unpack(size)[0]
 
         # Ensure that the buffer is large enough
         if len(self.buffer) < length:

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -400,7 +400,8 @@ class KaTeXServer:
             katex_path = os.path.join("./", katex_path)
             if not os.path.exists(os.path.join(SRC_DIR, katex_path)):
                 raise ValueError(
-                    f"KaTeX Javascript library could not be found at {katex_path}."
+                    "KaTeX Javascript library could not be found "
+                    f"at {katex_path}."
                 )
             katex_path = katex_path[:-3]  # remove `.js`
             cmd.extend(["--katex", katex_path])

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -387,7 +387,7 @@ class KaTeXServer:
 
         if cls.KATEX_PATH is not None:
             print(f"DEBUG: add {cls.KATEX_PATH=}")
-            cmd.extend(["--katex", os.path.abspath(str(cls.KATEX_PATH)]))
+            cmd.extend(["--katex", os.path.abspath(str(cls.KATEX_PATH))])
         else:
             print(f"DEBUG: add {cls.KATEX_PATH=}")
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -186,6 +186,8 @@ def builder_inited(app):
         # https://github.com/KaTeX/KaTeX/blob/main/contrib/auto-render/README.md
         write_katex_autorenderer_file(app, filename_autorenderer)
         add_js(filename_autorenderer)
+    else:
+        KaTeXServer.KATEX_PATH = app.config.katex_js_path[:-3]  # remove `.js`
     # sphinxcontrib.katex custom CSS
     copy_file(app, filename_css)
     add_css(filename_css)
@@ -383,6 +385,7 @@ class KaTeXServer:
             cmd.extend(["--port", str(port)])
 
         if KATEX_PATH:
+            print(f"DEBUG: add {KATEX_PATH=}")
             cmd.extend(["--katex", str(KATEX_PATH)])
 
         return cmd

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -392,8 +392,8 @@ class KaTeXServer:
             # without `.js` at the end
             print(f"DEBUG: giveb {cls.KATEX_PATH=}")
             katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]
-            # relative path had to start with `"./"` for `require()` 
-            katex_path = os.path.join("./", katex_path)
+            # relative path had to start with `"./"` for `require()`
+            katex_path = os.path.join("./../sphinxcontrib/", katex_path)
             print(f"DEBUG: add {katex_path=}")
             cmd.extend(["--katex", katex_path])
         else:

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -185,7 +185,7 @@ def builder_inited(app):
         write_katex_autorenderer_file(app, filename_autorenderer)
         add_js(filename_autorenderer)
     else:
-        KaTeXServer.KATEX_PATH = app.config.katex_js_path[:-3]  # remove `.js`
+        KaTeXServer.KATEX_PATH = app.config.katex_js_path
     # sphinxcontrib.katex custom CSS
     copy_file(app, filename_css)
     add_css(filename_css)
@@ -386,9 +386,14 @@ class KaTeXServer:
             cmd.extend(["--port", str(port)])
 
         if cls.KATEX_PATH is not None:
+            # KaTeX will be included inside katex-server.js
+            # using `require()`,
+            # which needs the relative path to `katex.min.js`
+            # without `.js` at the end
             print(f"DEBUG: giveb {cls.KATEX_PATH=}")
-            print(f"DEBUG: add {os.path.abspath(str(cls.KATEX_PATH))=}")
-            cmd.extend(["--katex", os.path.abspath(str(cls.KATEX_PATH))])
+            katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]  # remove `.js`
+            print(f"DEBUG: add {katex_path=}")
+            cmd.extend(["--katex", katex_path])
         else:
             print(f"DEBUG: add {cls.KATEX_PATH=}")
 

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -391,10 +391,17 @@ class KaTeXServer:
             # which needs the relative path to `katex.min.js`
             # without `.js` at the end.
             # The default is to use `./katex.min.js`
-            katex_path = os.path.relpath(str(cls.katex_path))
+            print(f"{str(cls.katex_path)=}")
+            print(f"{os.path.abspath(str(cls.katex_path))=}")
+            katex_path = os.path.relpath(
+                os.path.abspath(str(cls.katex_path)),
+                start=SRC_DIR,
+            )
             # Relative path has to start with `"./"` for `require()`
             katex_path = os.path.join("./", katex_path)
-            if not os.path.exists(katex_path):
+            print(f"{katex_path=}")
+            print(f"{os.path.join(SRC_DIR, katex_path)=}")
+            if not os.path.exists(os.path.join(SRC_DIR, katex_path)):
                 raise ValueError(
                     f"KaTeX Javascript library could not be found at {katex_path}."
                 )

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -386,7 +386,8 @@ class KaTeXServer:
             cmd.extend(["--port", str(port)])
 
         if cls.KATEX_PATH is not None:
-            print(f"DEBUG: add {cls.KATEX_PATH=}")
+            print(f"DEBUG: giveb {cls.KATEX_PATH=}")
+            print(f"DEBUG: add {os.path.abspath(str(cls.KATEX_PATH))=}")
             cmd.extend(["--katex", os.path.abspath(str(cls.KATEX_PATH))])
         else:
             print(f"DEBUG: add {cls.KATEX_PATH=}")

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -391,7 +391,9 @@ class KaTeXServer:
             # which needs the relative path to `katex.min.js`
             # without `.js` at the end
             print(f"DEBUG: giveb {cls.KATEX_PATH=}")
-            katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]  # remove `.js`
+            katex_path = os.path.relpath(str(cls.KATEX_PATH))[:-3]
+            # relative path had to start with `"./"` for `require()` 
+            katex_path = os.path.join("./", katex_path)
             print(f"DEBUG: add {katex_path=}")
             cmd.extend(["--katex", katex_path])
         else:

--- a/sphinxcontrib/katex.py
+++ b/sphinxcontrib/katex.py
@@ -387,7 +387,7 @@ class KaTeXServer:
 
         if cls.KATEX_PATH is not None:
             print(f"DEBUG: add {cls.KATEX_PATH=}")
-            cmd.extend(["--katex", str(cls.KATEX_PATH)])
+            cmd.extend(["--katex", os.path.abspath(str(cls.KATEX_PATH)]))
         else:
             print(f"DEBUG: add {cls.KATEX_PATH=}")
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
+pytest
 toml

--- a/tests/test_katex_server.py
+++ b/tests/test_katex_server.py
@@ -16,6 +16,14 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
             "./katex.min",
         ),
         (
+            "./katex.min.js",
+            "./katex.min",
+        ),
+        (
+            os.path.join(".", "katex.min.js"),
+            "./katex.min",
+        ),
+        (
             os.path.join(CURRENT_DIR, "..", "sphinxcontrib", "katex.min.js"),
             "./katex.min",
         ),
@@ -45,4 +53,14 @@ def test_katex_server_js_path(katex_js_path, expected_require_path):
     KaTeXServer.katex_path = katex_js_path
     cmd = KaTeXServer.build_command()
     assert cmd[-1] == expected_require_path
-    assert False
+
+
+def test_katex_server_js_path_error():
+    katex_js_path = "non-existing.js"
+    error_msg = (
+        "KaTeX Javascript library could not be found at "
+        f"{os.path.join('.', katex_js_path)}."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        KaTeXServer.katex_path = katex_js_path
+        KaTeXServer.build_command()

--- a/tests/test_katex_server.py
+++ b/tests/test_katex_server.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+
+from sphinxcontrib.katex import KaTeXServer
+
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.mark.parametrize(
+    "katex_js_path, expected_require_path",
+    [
+        (
+            "katex.min.js",
+            "./katex.min",
+        ),
+        (
+            os.path.join(CURRENT_DIR, "..", "sphinxcontrib", "katex.min.js"),
+            "./katex.min",
+        ),
+    ],
+)
+def test_katex_server_js_path(katex_js_path, expected_require_path):
+    """Test configured KaTeX Javascript library path.
+
+    When using the pre-rendering capabilities
+    of the ``sphinxcontrib.katex`` sphinx extension,
+    it requires a KaTeX Javascript library
+    provided by the file
+    specified in the config value ``katex_js_path``.
+
+    Args:
+        kates_js_path: path specified for the ``katex_js_path``
+            config path variable
+        expected_require_path: expected path
+            to the KaTeX Javascript library as provided
+            to the Javascript ``require()`` function.
+            The path needs to be relative
+            to the path of ``katex-server.js``
+            always starts with ``./``,
+            and exclude the file extension
+
+    """
+    KaTeXServer.katex_path = katex_js_path
+    cmd = KaTeXServer.build_command()
+    assert cmd[-1] == expected_require_path
+    assert False

--- a/tests/test_katex_server.py
+++ b/tests/test_katex_server.py
@@ -39,7 +39,7 @@ def test_katex_server_js_path(katex_js_path, expected_require_path):
     specified in the config value ``katex_js_path``.
 
     Args:
-        kates_js_path: path specified for the ``katex_js_path``
+        katex_js_path: path specified for the ``katex_js_path``
             config path variable
         expected_require_path: expected path
             to the KaTeX Javascript library as provided

--- a/tests/test_katex_server.py
+++ b/tests/test_katex_server.py
@@ -56,6 +56,7 @@ def test_katex_server_js_path(katex_js_path, expected_require_path):
 
 
 def test_katex_server_js_path_error():
+    """Test errors for configured KaTeX Javascript library path."""
     katex_js_path = "non-existing.js"
     error_msg = (
         "KaTeX Javascript library could not be found at "


### PR DESCRIPTION
Relates to #122 

This uses the value from `katex_js_path` for the path to the KaTeX executable, used inside ` katex-server.js` to render the pages in pre-render mode. The default value of `katex_js_path` points to the KaTeX Javascript library bundled with this extension, but the user can point to another file on the local machine.