### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
       sphinx-version: '5.*'
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sphinx-legacy.yml
+++ b/.github/workflows/sphinx-legacy.yml
@@ -39,6 +39,8 @@ jobs:
         pip install "sphinxcontrib-htmlhelp<=2.0.1"
         pip install "sphinxcontrib-qthelp<=1.0.3"
         pip install "sphinxcontrib-serializinghtml<=1.1.5"
+        # Ensure alabaster theme is still compatible
+        pip install "alabaster<=0.7.13"
 
     - name: Tests
       run: |

--- a/.github/workflows/sphinx-legacy.yml
+++ b/.github/workflows/sphinx-legacy.yml
@@ -32,6 +32,13 @@ jobs:
         pip install "sphinx==${{ matrix.sphinx-version }}"
         pip install "docutils<0.17"
         pip install "jinja2<3.1"
+        # Ensure extensions required by sphinx are still compatible
+        # (https://github.com/sphinx-doc/sphinx/issues/11890)
+        pip install "sphinxcontrib-applehelp<=1.0.4"
+        pip install "sphinxcontrib-devhelp<=1.0.2"
+        pip install "sphinxcontrib-htmlhelp<=2.0.1"
+        pip install "sphinxcontrib-qthelp<=1.0.3"
+        pip install "sphinxcontrib-serializinghtml<=1.1.5"
 
     - name: Tests
       run: |

--- a/.github/workflows/sphinx-legacy.yml
+++ b/.github/workflows/sphinx-legacy.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      python-version: '3.8'
+      python-version: '3.9'
     strategy:
       matrix:
         sphinx-version: [ '1.6.7', '1.8.6', '2.4.5', '3.5.4', '4.5.0' ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Remove support for Python 3.8 as it has reached its end of life, and remove all tests as we also no longer have runner available.