### PR TITLE
Set python_requires >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     'sphinx >=1.6',
 ]
-requires-python = '>=3.7'
+requires-python = '>=3.9'
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)
 dynamic = ['version']


### PR DESCRIPTION
Ensure `python_requires` matches the actual required Python version.