### PR TITLE
Fix eq center alignment for pydata-sphinx-theme

### DIFF
--- a/sphinxcontrib/katex-math.css
+++ b/sphinxcontrib/katex-math.css
@@ -22,6 +22,12 @@ div.math {
     position: relative;
     padding-right: 2.5em;
 }
+/* Support center alignment for pydata-sphinx-theme
+ * https://github.com/hagenw/sphinxcontrib-katex/issues/134
+ */
+div.math span:last-child {
+    flex-grow: 1;
+}
 .eqno {
     height: 100%;
     position: absolute;


### PR DESCRIPTION
Closes https://github.com/hagenw/sphinxcontrib-katex/issues/134

The proposed fix changes

![image](https://github.com/user-attachments/assets/34ed0e83-457c-4e0d-b5a2-b4501a5dfe7c)

to

![image](https://github.com/user-attachments/assets/cf0d410f-b1c8-4895-86ab-692845d10b5a)

for the widely used `pydata-sphinx-theme`.

