### PR TITLE
CI: update RTD config to support uv

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Test for broken links
       run: |
-        uv run python -m sphinx docs/ docs/_build/ -b linkcheck -W -C
+        uv run python -m sphinx docs/ docs/_build/ -b linkcheck -W -C -D linkcheck_ignore='["https://pypi.org/project/sphinxcontrib-katex"]'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,14 +6,20 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-24.04"
   tools:
-    python: "3.10"
+    python: "3.12"
     nodejs: "20"
+  jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync
+    install:
+      - "true"
   commands:
     - npm install --global "katex@0.16.22"
-    - pip install .
-    - pip install -r docs/requirements.txt
     - python -m sphinx docs $READTHEDOCS_OUTPUT/html -b html -W -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
 
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,17 +10,10 @@ build:
   tools:
     python: "3.12"
     nodejs: "20"
-  jobs:
-    create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync
-    install:
-      - "true"
   commands:
     - npm install --global "katex@0.16.22"
-    - python -m sphinx docs $READTHEDOCS_OUTPUT/html -b html -W -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
+    - pip install uv
+    - uv run python -m sphinx docs $READTHEDOCS_OUTPUT/html -b html -W -D master_doc=index -D extensions=sphinxcontrib.katex -D katex_prerender=1
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,10 @@ except Exception:
 # Code syntax highlighting style
 pygments_style = 'tango'
 
+linkcheck_ignore = [
+    "https://pypi.org/project/sphinxcontrib-katex",
+]
+
 # -- ACRONYMS AND MATH ---------------------------------------------------
 latex_macros = r"""
     \def \x                {\mathbf{x}}


### PR DESCRIPTION
Follows https://github.com/astral-sh/uv/issues/10074 to update the Read The Docs config file to work with `uv` instead of `pip`.